### PR TITLE
ldnode as command line tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "./node_modules/mocha/bin/mocha ./test/test.js"
+  },
+  "bin": {
+    "ldnode": "./server.js"
   }
 }


### PR DESCRIPTION
By adding `bin: 'server.js'`, we can now install ldnode with

```
npm install -g ldnode
```

And tun `ldnode` as a command line