### PR TITLE
Use system-wide ACL notation in ACL module

### DIFF
--- a/acl.js
+++ b/acl.js
@@ -13,10 +13,10 @@ var file = require('./fileStore.js');
 var ns = require('./vocab/ns.js').ns;
 var rdfVocab = require('./vocab/rdf.js');
 
-var aclExtension = ".acl";
-
 function allow(mode, req, res) {
     var options = req.app.locals.ldp;
+    var aclExtension = options.aclSuffix;
+
     var origin = req.get('origin');
     origin = origin ? origin : '';
 

--- a/options.js
+++ b/options.js
@@ -11,7 +11,8 @@ module.exports = params;
 function params(argv) {
   var opts = {};
   opts.leavePatchConnectionOpen = false;
-  opts.aclSuffix = argv.aclSuffix || ",acl";
+  opts.aclSuffix = argv.aclSuffix || ".acl";
+  opts.metaSuffix = argv.metaSuffix || ".meta";
   opts.uriBase = argv.uriBase ||
       'http://localhost:3000' + process.cwd() + '/test/';
   opts.fileBase = argv.fileBase || process.cwd() + '/test/';
@@ -20,7 +21,7 @@ function params(argv) {
   }
   opts.address = argv.a || '0.0.0.0';
   opts.verbose = argv.v;
-  opts.changesSuffix = argv.changesSuffix || ',changes';
+  opts.changesSuffix = argv.changesSuffix || '.changes';
   opts.SSESuffix = argv.SSESuffix || ',events';
   opts.ssl = argv.S;
   opts.cors = argv.cors;
@@ -49,7 +50,7 @@ function params(argv) {
 
   // TODO this should be an attribute of an object
   opts.usedURIs = {};
-  
+
   debug("URI path filter regexp: " + opts.pathFilter);
   debug("Verbose: " + opts.verbose);
   debug("Live: " + opts.live);


### PR DESCRIPTION
The ACL module was using a hardcoded notation (i.e. ".acl") for ACL suffixes, although the aclSuffix param is available at runtime.