### PR TITLE
Modified get handler for containers to match Solid spec.

### DIFF
--- a/handlers/get.js
+++ b/handlers/get.js
@@ -12,12 +12,14 @@ var debug = require('../logging').handlers;
 var acl = require('../acl.js');
 var header = require('../header.js');
 var metadata = require('../metadata.js');
+var ns = require('../vocab/ns.js').ns;
 var options = require('../options.js');
 var file = require('../fileStore.js');
 var subscription = require('../subscription.js');
 
 var ldpVocab = require('../vocab/ldp.js');
 var metaExtension = '.meta';
+var turtleExtension = '.ttl';
 
 function get(req, res, includeBody) {
     var options = req.app.locals.ldp;
@@ -126,7 +128,6 @@ function get(req, res, includeBody) {
             }
 
             // Matches found
-            debug("matches " + matches);
             var globGraph = $rdf.graph();
             matches.forEach(function(match) {
                 try {
@@ -230,6 +231,16 @@ function get(req, res, includeBody) {
             return res.status(500).send(err);
         }
 
+        try {
+            var containerStats = fs.statSync(filename);
+            resourceGraph.add(resourceGraph.sym(baseUri),
+                              ns.stat('mtime'),
+                              containerStats.mtime.getTime());
+            resourceGraph.add(resourceGraph.sym(baseUri),
+                              ns.stat('size'),
+                              containerStats.size);
+        } catch (statErr) {}
+
         debug("GET/HEAD -- Reading directory");
         fs.readdir(filename, readdirCallback);
 
@@ -238,16 +249,66 @@ function get(req, res, includeBody) {
                 debug("GET/HEAD -- Error reading files: " + err);
                 return res.sendStatus(404);
             } else {
+                debug("Files in directory: " + files);
                 for (var i = 0; i < files.length; i++) {
-                    if (!S(files[i]).startsWith('.')) {
+                    if (!S(files[i]).endsWith(metaExtension) &&
+                        !S(files[i]).endsWith(options.suffixAcl)) {
                         try {
                             var stats = fs.statSync(filename + files[i]);
-                            if (stats.isFile()) {
-                                resourceGraph.add(resourceGraph.sym(baseUri),
-                                    resourceGraph.sym(ldpVocab.contains),
-                                    resourceGraph.sym(files[i]));
+
+                            resourceGraph.add(resourceGraph.sym(baseUri),
+                                              ns.ldp('contains'),
+                                              resourceGraph.sym(files[i]));
+
+                            var metaFile;
+                            var fileBaseUri;
+                            var fileSubject = files[i];
+
+                            if(stats.isDirectory()) {
+                                metaFile = filename + files[i] + '/' + metaExtension;
+                                fileSubject += '/';
+                            } else if (stats.isFile() && S(files[i]).endsWith(turtleExtension)) {
+                                metaFile = filename + files[i];
+                            } else {
+                                metaFile = filename + files[i] + metaExtension;
                             }
-                        } catch (statErr) {
+                            fileBaseUri = file.filenameToBaseUri(files[i], uri, options.root);
+
+                            var metadataGraph = $rdf.graph();
+                            var rawMetadata;
+
+                            if (fs.existsSync(metaFile)) {
+                                try {
+                                    rawMetadata = fs.readFileSync(metaFile, {encoding: 'utf8'});
+                                    $rdf.parse(rawMetadata, metadataGraph, fileBaseUri,
+                                               'text/turtle');
+                                } catch (dirErr) {
+                                    metadataGraph = $rdf.graph();
+                                }
+                            }
+
+                            var typeStatements = metadataGraph
+                                    .statementsMatching(metadataGraph.sym(fileBaseUri),
+                                                        ns.rdf('type'), undefined);
+                            for (var typeIndex in typeStatements) {
+                                var typeStatement = typeStatements[typeIndex];
+                                resourceGraph.add(resourceGraph.sym(fileSubject),
+                                                  typeStatement.predicate,
+                                                  typeStatement.object);
+
+                            }
+
+                            try {
+                                var fileStats = fs.statSync(filename + files[i]);
+                                resourceGraph.add(metadataGraph.sym(fileSubject),
+                                                  ns.stat('mtime'),
+                                                  fileStats.mtime.getTime());
+                                resourceGraph.add(metadataGraph.sym(fileSubject),
+                                                  ns.stat('size'),
+                                                  fileStats.size);
+                            } catch (statErr) {}
+                        } catch (getErr) {
+                            debug("Error getting container: " + getErr);
                             continue;
                         }
                     }

--- a/vocab/ns.js
+++ b/vocab/ns.js
@@ -10,5 +10,6 @@ exports.ns = {
     cert: $rdf.Namespace("http://www.w3.org/ns/auth/cert#"),
     foaf: $rdf.Namespace("http://xmlns.com/foaf/0.1/"),
     stat: $rdf.Namespace("http://www.w3.org/ns/posix/stat#"),
-    dct:  $rdf.Namespace("http://purl.org/dc/terms/")
+    dct:  $rdf.Namespace("http://purl.org/dc/terms/"),
+    ldp:  $rdf.Namespace("http://www.w3.org/ns/ldp#")
 };


### PR DESCRIPTION
I work on getting the get handler to follow the Solid spec (https://github.com/linkeddata/SoLiD#reading-resources). I only tested manually but I will work on an automated test later. I am pretty sure the code is correct but I am attaching the output for reference.

Request:
```
 GET /
```
Response body:
```
@prefix loc: <http://localhost:3456/>.
@prefix ldp: <http://www.w3.org/ns/ldp#>.
@prefix st: <http://www.w3.org/ns/posix/stat#>.
@prefix tes: <testfiles/>.

loc:
    ldp:contains
        <.permissions>,
        <Makefile>,
        <acl.js>,
        <cert.pem>,
        <empty.spatch>,
        <hello.html>,
        <key.pem>,
        <ldpatch-example-final.ttl>,
        <ldpatch-example-initial.ttl>,
        <ldpatch-example-patch-1.spatch>,
        <ldpatch-example-patch-2.spatch>,
        <ldpatch-example-patch-3.spatch>,
        <ldpatch-example-patch.ldpatch>,
        <ldpatch-example-patch.spatch>,
        <lfs-0.sparql>,
        <lfs-1-final.json>,
        <lfs-1.sparql>,
        <params.js>,
        <patch-1-initial.ttl>,
        <patch-2-final.ttl>,
        <patch-2-initial.ttl>,
        <patch-2.spatch>,
        <patch-2n.spatch>,
        <patch-3-final.ttl>,
        <patch-4-final.ttl>,
        <patch-5-final.ttl>,
        <patch-5-initial.ttl>,
        <patch-5.spatch>,
        <patch.js>,
        <put-input-2.html>,
        <put-input.txt>,
        <test.js>,
        <testfiles>;
    st:mtime
       1436913921000;
    st:size
       4096.
   <.permissions> st:mtime 1436826569000; st:size 147 .
   <Makefile> st:mtime 1436826569000; st:size 5396 .
   <acl.js> st:mtime 1436900989000; st:size 42781 .
   <cert.pem> st:mtime 1436826569000; st:size 1261 .
   <empty.spatch> st:mtime 1436826135000; st:size 0 .
   <hello.html> st:mtime 1436826569000; st:size 42 .
   <key.pem> st:mtime 1436826569000; st:size 1679 .
   <ldpatch-example-final.ttl> st:mtime 1436826135000; st:size 774 .
   <ldpatch-example-initial.ttl> st:mtime 1436826135000; st:size 724 .
   <ldpatch-example-patch-1.spatch> st:mtime 1436826135000; st:size 275 .
   <ldpatch-example-patch-2.spatch> st:mtime 1436826135000; st:size 392 .
   <ldpatch-example-patch-3.spatch> st:mtime 1436826135000; st:size 485 .
   <ldpatch-example-patch.ldpatch> st:mtime 1436826135000; st:size 840 .
   <ldpatch-example-patch.spatch> st:mtime 1436826135000; st:size 772 .
   <lfs-0.sparql> st:mtime 1436826569000; st:size 410 .
   <lfs-1-final.json> st:mtime 1436826569000; st:size 92 .
   <lfs-1.sparql> st:mtime 1436826569000; st:size 461 .
   <params.js> st:mtime 1436844380000; st:size 3014 .
   <patch-1-initial.ttl> st:mtime 1436826135000; st:size 24 .
   <patch-2-final.ttl> st:mtime 1436826135000; st:size 28 .
   <patch-2-initial.ttl> st:mtime 1436826135000; st:size 24 .
   <patch-2.spatch> st:mtime 1436826135000; st:size 69 .
   <patch-2n.spatch> st:mtime 1436826135000; st:size 69 .
   <patch-3-final.ttl> st:mtime 1436826135000; st:size 783 .
   <patch-4-final.ttl> st:mtime 1436826135000; st:size 810 .
   <patch-5-final.ttl> st:mtime 1436826135000; st:size 31 .
   <patch-5-initial.ttl> st:mtime 1436826135000; st:size 90 .
   <patch-5.spatch> st:mtime 1436826135000; st:size 91 .
   <patch.js> st:mtime 1436844380000; st:size 4910 .
   <put-input-2.html> st:mtime 1436826135000; st:size 236 .
   <put-input.txt> st:mtime 1436826135000; st:size 136 .
   <test.js> st:mtime 1436844380000; st:size 7221 .
tes:
    a    ldp:BasicContainer, ldp:Container, st:Directory;
    st:mtime
       1436920726000;
    st:size
       4096.
```