### PR TITLE
Simplifying login

### DIFF
--- a/login.js
+++ b/login.js
@@ -6,60 +6,56 @@ var debug = require('./logging').login;
 
 function loginHandler(req, res, next) {
     var options = req.app.locals.ldp;
-    if (!options.webid) {
-        setEmptySession(req);
-        return next();
-    }
+
+    // User already logged in
     if (req.session.userId && req.session.identified) {
         debug("User: " + req.session.profile);
         res.set('User', req.session.userId);
         return next();
-    } else {
-        var certificate = req.connection.getPeerCertificate();
-        if (!(certificate === null || Object.keys(certificate).length === 0))  {
-            var verifAgent = new webid.VerificationAgent(certificate);
-            verifAgent.verify(function(err, result) {
-                if (err) {
-                    var message;
-                    switch (err) {
-                    case 'certificateProvidedSAN':
-                        message = 'No valide Certificate Alternative Name in your certificate';
-                        break;
-                    case 'profileWellFormed':
-                        message = 'Can\'t load your foaf file (RDF may not be valid)';
-                        break;
-                    case 'falseWebID':
-                        message = 'Your certificate public key is not the one of the FOAF file';
-                        break;
-                    case 'profileAllKeysWellFormed':
-                        message = "Missformed WebID";
-                        break;
-                    default:
-                        message = "Unknown WebID error";
-                        break;
-                    }
-                    debug("Error processing certificate: " + message);
-                    setEmptySession(req);
-                    return res.status(403).send(message);
-                } else {
-                    req.session.userId = result;
-                    req.session.identified = true;
-                    debug("Identified user: " + req.session.userId);
-                    res.set('User', req.session.userId);
-                    return next();
-                }
-            });
-        } else {
-            debug("Empty certificate");
-            setEmptySession(req);
-            next();
-        }
     }
 
-    function setEmptySession(req) {
-        req.session.userId = "";
-        req.session.identified = false;
+    // Empty certificate
+    var certificate = req.connection.getPeerCertificate();
+    if (certificate === null || Object.keys(certificate).length === 0)  {
+        debug("Empty certificate");
+        return next();
     }
+
+    // Valid certificate
+    var verifAgent = new webid.VerificationAgent(certificate);
+    verifAgent.verify(function(err, result) {
+        // Error with certificate
+        if (err) {
+            var message;
+            switch (err) {
+            case 'certificateProvidedSAN':
+                message = 'No valide Certificate Alternative Name in your certificate';
+                break;
+            case 'profileWellFormed':
+                message = 'Can\'t load your foaf file (RDF may not be valid)';
+                break;
+            case 'falseWebID':
+                message = 'Your certificate public key is not the one of the FOAF file';
+                break;
+            case 'profileAllKeysWellFormed':
+                message = "Missformed WebID";
+                break;
+            default:
+                message = "Unknown WebID error";
+                break;
+            }
+            debug("Error processing certificate: " + message);
+            return res.status(403).send(message);
+        }
+        
+        // Setting the user
+        req.session.userId = result;
+        req.session.identified = true;
+        debug("Identified user: " + req.session.userId);
+        res.set('User', req.session.userId);
+        return next();
+    });
+
 }
 
 exports.loginHandler = loginHandler;


### PR DESCRIPTION
Mainly it removes `setEmptySession` to avoid setting `req.session.webid = ""`, whose type is string, instead of `undefined`.

**Only merge on tests passing**