### PR TITLE
ACL path

### DIFF
--- a/acl.js
+++ b/acl.js
@@ -209,8 +209,6 @@ function allow(mode, req) {
         if (i === 0) {
             if (path.dirname(path.dirname(relativePath)) == '.') {
                 filepath = options.root;
-            } else if (S(relativePath).endsWith("/")) {
-                filepath = options.root + path.dirname(path.dirname(relativePath));
             } else {
                 filepath = options.root + path.dirname(relativePath);
             }
@@ -220,7 +218,7 @@ function allow(mode, req) {
             } else if (path.dirname(path.dirname(relativePath)) === '.') {
                 filepath = options.root;
             } else {
-                filepath = options.root + path.dirname(path.dirname(relativePath));
+                filepath = options.root + path.dirname(relativePath);
             }
         }
 


### PR DESCRIPTION
Turns out I had correctly transcribed the code from gold into ldnode but go's Dir and node's dirname have different behaviour when the path has a trailing slash.

In gold
```
pathfile.Dir("/home/martinmr/) // returns "/home/martinmr
```
while in node
```
path.dirname("/home/martinmr/") // returns "/home"
```