### PR TITLE
Return Unix type timestamp (trim last 3 zeros)

### DIFF
--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -121,7 +121,7 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
     resourceGraph.add(
       resourceGraph.sym(baseUri),
       ns.stat('mtime'),
-      stats.mtime.getTime());
+      stats.mtime.getTime() / 1000);
 
     resourceGraph.add(
       resourceGraph.sym(baseUri),


### PR DESCRIPTION
`getTime()` currently returns the `mtime` in milliseconds, which does not conform to Unix style. This PR removes the last three zeros (milliseconds) since they are not useful -- the date obtained from `stat` is only accurate to the second.