### PR TITLE
Set acl and describedBy (meta) Link headers for all requests.

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -57,20 +57,6 @@ function get(req, res, includeBody) {
         debug('HEAD -- ' + req.originalUrl);
     }
 
-    // Add ACL and Meta Link in header
-    var aclLink = utils.getResourceLink(
-        filename, uri,
-        ldp.root, ldp.suffixAcl,
-        ldp.suffixMeta);
-
-    var metaLink = utils.getResourceLink(
-        filename, uri,
-        ldp.root, ldp.suffixMeta,
-        ldp.suffixAcl);
-
-    header.addLink(res, aclLink, 'acl');
-    header.addLink(res, metaLink, 'describedBy');
-
     // Get resource or container
     ldp.get(filename, uri, includeBody, function(err, data, container) {
 

--- a/lib/header.js
+++ b/lib/header.js
@@ -4,6 +4,7 @@ var path = require('path');
 var S = require('string');
 var Negotiator = require('negotiator');
 var metadata = require('./metadata.js');
+var ldp = require('./ldp.js');
 var utils = require('./utils.js');
 var ldpVocab = require('./vocab/ldp.js');
 
@@ -30,6 +31,7 @@ function addLinks(res, fileMetadata) {
 }
 
 function linksHandler(req, res, next) {
+    var uri = utils.uriBase(req);
     var ldp = req.app.locals.ldp;
     var filename = utils.uriToFilename(req.url, ldp.root);
 
@@ -45,6 +47,22 @@ function linksHandler(req, res, next) {
     } else {
         fileMetadata.isResource = true;
     }
+
+    // Add ACL and Meta Link in header
+    var aclLink = utils.getResourceLink(
+        filename, uri,
+        ldp.root, ldp.suffixAcl,
+        ldp.suffixMeta);
+
+    var metaLink = utils.getResourceLink(
+        filename, uri,
+        ldp.root, ldp.suffixMeta,
+        ldp.suffixAcl);
+
+    addLink(res, aclLink, 'acl');
+    addLink(res, metaLink, 'describedBy');
+
+
     addLinks(res, fileMetadata);
     next();
 }

--- a/lib/header.js
+++ b/lib/header.js
@@ -59,8 +59,8 @@ function linksHandler(req, res, next) {
         ldp.root, ldp.suffixMeta,
         ldp.suffixAcl);
 
-    addLink(res, aclLink, 'acl');
-    addLink(res, metaLink, 'describedBy');
+    addLink(res, utils.uriRelative(aclLink), 'acl');
+    addLink(res, utils.uriRelative(metaLink), 'describedBy');
 
 
     addLinks(res, fileMetadata);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,8 +42,8 @@ function uriBase(req) {
     return uriAbs(req) + (req.baseUrl || '');
 }
 
-function uriRelative(uri, base) {
-    var relative = path.relative(base, uri);
+function uriRelative(uri) {
+    var relative = path.basename(uri);
     return relative;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,6 +42,11 @@ function uriBase(req) {
     return uriAbs(req) + (req.baseUrl || '');
 }
 
+function uriRelative(uri, base) {
+    var relative = path.relative(base, uri);
+    return relative;
+}
+
 function getResourceLink(filename, uri, base, suffix, otherSuffix) {
     var link = filenameToBaseUri(filename, uri, base);
     if (S(link).endsWith(suffix)) {
@@ -76,6 +81,7 @@ exports.uriToFilename = uriToFilename;
 exports.uriToRelativeFilename = uriToRelativeFilename;
 exports.filenameToBaseUri = filenameToBaseUri;
 exports.uriAbs = uriAbs;
+exports.uriRelative = uriRelative;
 exports.uriBase = uriBase;
 exports.getResourceLink = getResourceLink;
 exports.formatDateTime = formatDateTime;


### PR DESCRIPTION
ldnode was previously only setting the acl and describedBy (meta) Link headers only for GET. The PR sets the Link headers for all request methods. 

It also fixes #112 