### PR TITLE
Improved the function that makes Link URIs relative

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -49,8 +49,8 @@ function linksHandler(req, res, next) {
     }
 
     // Add ACL and Meta Link in header
-    addLink(res, utils.basename(req.path) + ldp.suffixAcl, 'acl');
-    addLink(res, utils.basename(req.path) + ldp.suffixMeta, 'describedBy');
+    addLink(res, utils.basePathName(req.path) + ldp.suffixAcl, 'acl');
+    addLink(res, utils.basePathName(req.path) + ldp.suffixMeta, 'describedBy');
     // Add other Link headers
     addLinks(res, fileMetadata);
     next();

--- a/lib/header.js
+++ b/lib/header.js
@@ -49,20 +49,9 @@ function linksHandler(req, res, next) {
     }
 
     // Add ACL and Meta Link in header
-    var aclLink = utils.getResourceLink(
-        filename, uri,
-        ldp.root, ldp.suffixAcl,
-        ldp.suffixMeta);
-
-    var metaLink = utils.getResourceLink(
-        filename, uri,
-        ldp.root, ldp.suffixMeta,
-        ldp.suffixAcl);
-
-    addLink(res, utils.basename(aclLink), 'acl');
-    addLink(res, utils.basename(metaLink), 'describedBy');
-
-
+    addLink(res, utils.basename(req.url) + ldp.suffixAcl, 'acl');
+    addLink(res, utils.basename(req.url) + ldp.suffixMeta, 'describedBy');
+    // Add other Link headers
     addLinks(res, fileMetadata);
     next();
 }

--- a/lib/header.js
+++ b/lib/header.js
@@ -49,8 +49,8 @@ function linksHandler(req, res, next) {
     }
 
     // Add ACL and Meta Link in header
-    addLink(res, utils.basename(req.url) + ldp.suffixAcl, 'acl');
-    addLink(res, utils.basename(req.url) + ldp.suffixMeta, 'describedBy');
+    addLink(res, utils.basename(req.path) + ldp.suffixAcl, 'acl');
+    addLink(res, utils.basename(req.path) + ldp.suffixMeta, 'describedBy');
     // Add other Link headers
     addLinks(res, fileMetadata);
     next();

--- a/lib/header.js
+++ b/lib/header.js
@@ -49,8 +49,8 @@ function linksHandler(req, res, next) {
     }
 
     // Add ACL and Meta Link in header
-    addLink(res, utils.basePathName(req.path) + ldp.suffixAcl, 'acl');
-    addLink(res, utils.basePathName(req.path) + ldp.suffixMeta, 'describedBy');
+    addLink(res, utils.pathBasename(req.path) + ldp.suffixAcl, 'acl');
+    addLink(res, utils.pathBasename(req.path) + ldp.suffixMeta, 'describedBy');
     // Add other Link headers
     addLinks(res, fileMetadata);
     next();

--- a/lib/header.js
+++ b/lib/header.js
@@ -59,8 +59,8 @@ function linksHandler(req, res, next) {
         ldp.root, ldp.suffixMeta,
         ldp.suffixAcl);
 
-    addLink(res, utils.uriRelative(aclLink), 'acl');
-    addLink(res, utils.uriRelative(metaLink), 'describedBy');
+    addLink(res, utils.basename(aclLink), 'acl');
+    addLink(res, utils.basename(metaLink), 'describedBy');
 
 
     addLinks(res, fileMetadata);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ function uriBase(req) {
     return uriAbs(req) + (req.baseUrl || '');
 }
 
-function basePathName(fullpath) {
+function pathBasename(fullpath) {
     var bname = '';
     if (fullpath) {
         bname = (fullpath.lastIndexOf('/') === fullpath.length - 1)?'':path.basename(fullpath);
@@ -84,7 +84,7 @@ exports.uriToFilename = uriToFilename;
 exports.uriToRelativeFilename = uriToRelativeFilename;
 exports.filenameToBaseUri = filenameToBaseUri;
 exports.uriAbs = uriAbs;
-exports.basePathName = basePathName;
+exports.pathBasename = pathBasename;
 exports.uriBase = uriBase;
 exports.getResourceLink = getResourceLink;
 exports.formatDateTime = formatDateTime;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,10 @@ function uriBase(req) {
 }
 
 function basename(fullpath) {
-    var bname = (fullpath.lastIndexOf('/') === fullpath.length - 1)?'':path.basename(fullpath);
+    var bname = '';
+    if (fullpath) {
+        bname = (fullpath.lastIndexOf('/') === fullpath.length - 1)?'':path.basename(fullpath);
+    }
     return bname;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,9 +42,9 @@ function uriBase(req) {
     return uriAbs(req) + (req.baseUrl || '');
 }
 
-function uriRelative(uri) {
-    var relative = path.basename(uri);
-    return relative;
+function basename(fullpath) {
+    var bname = (fullpath.lastIndexOf('/') === fullpath.length - 1)?'':path.basename(fullpath);
+    return bname;
 }
 
 function getResourceLink(filename, uri, base, suffix, otherSuffix) {
@@ -81,7 +81,7 @@ exports.uriToFilename = uriToFilename;
 exports.uriToRelativeFilename = uriToRelativeFilename;
 exports.filenameToBaseUri = filenameToBaseUri;
 exports.uriAbs = uriAbs;
-exports.uriRelative = uriRelative;
+exports.basename = basename;
 exports.uriBase = uriBase;
 exports.getResourceLink = getResourceLink;
 exports.formatDateTime = formatDateTime;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ function uriBase(req) {
     return uriAbs(req) + (req.baseUrl || '');
 }
 
-function basename(fullpath) {
+function basePathName(fullpath) {
     var bname = '';
     if (fullpath) {
         bname = (fullpath.lastIndexOf('/') === fullpath.length - 1)?'':path.basename(fullpath);
@@ -84,7 +84,7 @@ exports.uriToFilename = uriToFilename;
 exports.uriToRelativeFilename = uriToRelativeFilename;
 exports.filenameToBaseUri = filenameToBaseUri;
 exports.uriAbs = uriAbs;
-exports.basename = basename;
+exports.basePathName = basePathName;
 exports.uriBase = uriBase;
 exports.getResourceLink = getResourceLink;
 exports.formatDateTime = formatDateTime;

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,18 @@
+var assert = require('chai').assert;
+
+var utils = require('../lib/utils');
+
+describe('Utility functions', function() {
+
+  describe('basename', function() {
+    it('should return bar as relative path', function() {
+      assert.equal(utils.basename('/foo/bar'), 'bar');
+    });
+    it('should return empty as relative path', function() {
+      assert.equal(utils.basename('/foo/'), '');
+    });
+    it('should return empty as relative path', function() {
+      assert.equal(utils.basename('/'), '');
+    });
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,14 +5,20 @@ var utils = require('../lib/utils');
 describe('Utility functions', function() {
 
   describe('basename', function() {
-    it('should return bar as relative path', function() {
+    it('should return bar as relative path for /foo/bar', function() {
       assert.equal(utils.basename('/foo/bar'), 'bar');
     });
-    it('should return empty as relative path', function() {
+    it('should return empty as relative path for /foo/', function() {
       assert.equal(utils.basename('/foo/'), '');
     });
-    it('should return empty as relative path', function() {
+    it('should return empty as relative path for /', function() {
       assert.equal(utils.basename('/'), '');
+    });
+    it('should return empty as relative path for empty path', function() {
+      assert.equal(utils.basename(''), '');
+    });
+    it('should return empty as relative path for undefined path', function() {
+      assert.equal(utils.basename(undefined), '');
     });
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,19 +6,19 @@ describe('Utility functions', function() {
 
   describe('basename', function() {
     it('should return bar as relative path for /foo/bar', function() {
-      assert.equal(utils.basename('/foo/bar'), 'bar');
+      assert.equal(utils.basePathName('/foo/bar'), 'bar');
     });
     it('should return empty as relative path for /foo/', function() {
-      assert.equal(utils.basename('/foo/'), '');
+      assert.equal(utils.basePathName('/foo/'), '');
     });
     it('should return empty as relative path for /', function() {
-      assert.equal(utils.basename('/'), '');
+      assert.equal(utils.basePathName('/'), '');
     });
     it('should return empty as relative path for empty path', function() {
-      assert.equal(utils.basename(''), '');
+      assert.equal(utils.basePathName(''), '');
     });
     it('should return empty as relative path for undefined path', function() {
-      assert.equal(utils.basename(undefined), '');
+      assert.equal(utils.basePathName(undefined), '');
     });
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,21 +4,21 @@ var utils = require('../lib/utils');
 
 describe('Utility functions', function() {
 
-  describe('basename', function() {
+  describe('pathBasename', function() {
     it('should return bar as relative path for /foo/bar', function() {
-      assert.equal(utils.basePathName('/foo/bar'), 'bar');
+      assert.equal(utils.pathBasename('/foo/bar'), 'bar');
     });
     it('should return empty as relative path for /foo/', function() {
-      assert.equal(utils.basePathName('/foo/'), '');
+      assert.equal(utils.pathBasename('/foo/'), '');
     });
     it('should return empty as relative path for /', function() {
-      assert.equal(utils.basePathName('/'), '');
+      assert.equal(utils.pathBasename('/'), '');
     });
     it('should return empty as relative path for empty path', function() {
-      assert.equal(utils.basePathName(''), '');
+      assert.equal(utils.pathBasename(''), '');
     });
     it('should return empty as relative path for undefined path', function() {
-      assert.equal(utils.basePathName(undefined), '');
+      assert.equal(utils.pathBasename(undefined), '');
     });
   });
 });


### PR DESCRIPTION
This patch fixes the relative URIs in Link headers. I've added tests to make sure this happens according to the spec. For example:

* `HEAD https://example.org/foo/bar` will return a corresponding ACL link `bar.acl`, then
* `HEAD https://example.org/foo/` will return a corresponding ACL link `.acl`, and finally:
* `HEAD https://example.org/` will return a corresponding ACL link `.acl`

The `basename()` function does not require a `base` param. It only returns two possible outcomes: either the path is for a file (in which case it returns just the filename), or it returns an empty string if path ends with a `/`.