### PR TITLE
caching node-modules (travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - "0.12"
-
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
In this way, travis does not reinstall every time the dependencies (some of them are really slow).

In case we update the dependencies, we can use the web interface (Settings -> delete all repository caches)