### PR TITLE
use built-in express error handler

### DIFF
--- a/lib/handlers/error.js
+++ b/lib/handlers/error.js
@@ -5,25 +5,24 @@ var fs = require('fs');
 
 function errorPageHandler(err, req, res, next) {
     var ldp = req.app.locals.ldp;
-    if (!ldp.noErrorPages) {
-        var errorPage = ldp.errorPages +
-                err.status.toString() + '.html';
-        fs.readFile(errorPage, 'utf8', function(readErr, text) {
-            if (readErr) {
-                defaultErrorHandler(err, res);
-            } else {
-                res.status(err.status);
-                res.send(text);
-            }
-        });
-    } else {
-        defaultErrorHandler(err, res);
-    }
-}
 
-function defaultErrorHandler(err, res) {
-    res.status(err.status);
-    res.send(err.message);
+    // If noErrorPages is set,
+    // then use built-in express default error handler
+    if (ldp.noErrorPages) {
+        return next(err);
+    }
+
+    // Check if error page exists
+    var errorPage = ldp.errorPages + err.status.toString() + '.html';
+    fs.readFile(errorPage, 'utf8', function(readErr, text) {
+        if (readErr) {
+            return next();
+        }
+
+        res.status(err.status);
+        res.header('Content-Type', 'text/html');
+        res.send(text);
+    });
 }
 
 exports.handler = errorPageHandler;


### PR DESCRIPTION
In this way, we never do `res.send(err.message)`, so we allow the user to write its own handler (so my example in #110 works)