### PR TITLE
Use the real error messages from node-webid

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -20,29 +20,11 @@ function loginHandler(req, res, next) {
             var verifAgent = new webid.VerificationAgent(certificate);
             verifAgent.verify(function(err, result) {
                 if (err) {
-                    var message;
-                    switch (err) {
-                    case 'certificateProvidedSAN':
-                        message = 'No valide Certificate Alternative Name in your certificate';
-                        break;
-                    case 'profileWellFormed':
-                        message = 'Can\'t load your foaf file (RDF may not be valid)';
-                        break;
-                    case 'falseWebID':
-                        message = 'Your certificate public key is not the one of the FOAF file';
-                        break;
-                    case 'profileAllKeysWellFormed':
-                        message = "Certificate public key does not match the one found in the WebID profile.";
-                        break;
-                    default:
-                        message = "Unknown WebID error";
-                        break;
-                    }
-                    debug("Error processing certificate: " + message);
+                    debug("Error processing certificate: " + err);
                     setEmptySession(req);
                     var authError = new Error();
                     authError.status = 403;
-                    authError.message = message;
+                    authError.message = err;
                     return next(authError);
                 } else {
                     req.session.userId = result;
@@ -53,7 +35,7 @@ function loginHandler(req, res, next) {
                 }
             });
         } else {
-            debug("Empty certificate");
+            debug("No client certificate found in the request. Did the user click on a cert?");
             setEmptySession(req);
             next();
         }


### PR DESCRIPTION
Half the error codes in the switch() did not even exist anymore and/or were very cryptic. The new version of node-webid sends more verbose error codes, and we can just forward those directly to the debugger/printer.