### PR TITLE
Fixed weird [object Object] responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,6 @@ function routes () {
         getRawBody(req,
                    {
                        length: req.headers['content-length'],
-                       limit: '1mb',
                        encoding: 'utf-8' // typer.parse(req.headers['content-type']).parameters.charset
                    },
                    function(err, string) {

--- a/lib/handlers/error.js
+++ b/lib/handlers/error.js
@@ -9,7 +9,9 @@ function errorPageHandler(err, req, res, next) {
     // If noErrorPages is set,
     // then use built-in express default error handler
     if (ldp.noErrorPages) {
-        return next(err);
+        return res
+            .status(err.status)
+            .send(err.message);
     }
 
     // Check if error page exists

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -178,7 +178,7 @@ function aclAllow(match, req, res, callback) {
     var relativePath = '/' + path.relative(ldp.root, match);
     res.locals.path = relativePath;
     acl.allow("Read", req, res, function(err) {
-        callback(!err);
+        callback(err);
     });
 }
 
@@ -217,7 +217,7 @@ function parseLinkedData(req, res, next) {
     $rdf.serialize(undefined, resourceGraph, null, accept, function(err, result) {
         if (result === undefined || err) {
             debug("GET/HEAD -- Serialization error: " + err);
-            var serializeErr = new Error();
+            var serializeErr = {};
             serializeErr.status = 500;
             serializeErr.message = err.message;
             return next(serializeErr);


### PR DESCRIPTION
errorPageHandler() is supposed to catch all errors, so it now immediately returns the error status + message instead of forwarding it to next().