### PR TITLE
fixing issues with errors and enabling custom error handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ In case the `settings` is not passed, then it will start with the following defa
   suffixAcl: '.acl', // Suffix for acl files
   suffixChanges: '.changes', // Suffix for acl files
   suffixSSE: '.events', // Suffix for SSE files
-  proxy: false // Where to mount the proxy
+  proxy: false, // Where to mount the proxy
+  errorHandler: false, // function(err, req, res, next) to have a custom error handler
+  errorPages: false // specify a path where the error pages are
 }
 ```
 
@@ -100,7 +102,7 @@ ldp.listen(3000, function() {
 
 ##### Advanced
 
-You can integrate ldnode in your existing express app, by mounting the ldnode app on a specific path using `lnode(opts)`.
+You can integrate ldnode in your existing express app, by mounting the ldnode app on a specific path using `lnode(opts)`. Have a look at see [further examples](https://github.com/linkeddata/ldnode/tree/master/examples)
 
 ```javascript
 var ldnode = require('ldnode')

--- a/examples/custom-error-handling.js
+++ b/examples/custom-error-handling.js
@@ -1,0 +1,33 @@
+var ldnode = require('../'); // or require('ldnode')
+var path = require('path');
+
+ldnode
+  .createServer({
+    webid: true,
+    cert: path.resolve('./test/keys/cert.pem'),
+    key: path.resolve('./test/keys/key.pem'),
+    errorHandler: function(err, req, res, next) {
+      if (err.status !== 200) {
+        console.log('Oh no! There is an error:' + err.message);
+        res.status(err.status);
+
+        // Now you can send the error how you want
+        // Maybe you want to render an error page
+        // res.render('errorPage.ejs', {
+        //   title: err.status + ": This is an error!",
+        //   message: err.message
+        // })
+        // Or you want to respond in JSON?
+
+        res.json({
+          title: err.status + ": This is an error!",
+          message: err.message
+        });
+      }
+
+    }
+  })
+  .listen(3456, function() {
+    console.log('started ldp with webid on port ' + 3456);
+  });
+

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -13,6 +13,7 @@ var debug = require('./logging').ACL;
 var utils = require('./utils.js');
 var ns = require('./vocab/ns.js').ns;
 var rdfVocab = require('./vocab/rdf.js');
+var HttpError = require('./http-error');
 
 // TODO should this be set?
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
@@ -44,12 +45,16 @@ ACL.prototype.readACL = function(pathAcl, pathUri, callback) {
             debug("Error parsing ACL policy: " + err.message);
             return callback(err);
         }
+
         var aclGraph = $rdf.graph();
         try {
             $rdf.parse(aclData, aclGraph, pathUri, 'text/turtle');
-        } catch (parseErr) {
-            debug("Error parsing ACL policy: " + parseErr);
-            return callback({ status: 500, message: parseErr });
+        } catch (err) {
+            debug("Error parsing ACL policy: " + err);
+            return callback(new HttpError({
+                status: 500,
+                message: err.message
+            }));
         }
 
         return callback(null, aclGraph);
@@ -87,17 +92,17 @@ ACL.prototype.findACLinPath = function (mode, pathAcl, pathUri, aclGraph, access
             // User is authenticated
             if (userId.length === 0 || !acl.session || acl.session.identified === false)  {
                 debug("Authentication required");
-                return callback({
+                return callback(new HttpError({
                     status: 401,
                     message: "Access to " + pathUri + " requires authorization"
-                });
+                }));
             }
             // No ACL statement found, access is denied
             debug(mode + " access denied for: " + userId);
-            return callback({
+            return callback(new HttpError({
                 status: 403,
                 message: "Access denied for " + userId
-            });
+            }));
         });
     });
 

--- a/lib/handlers/error.js
+++ b/lib/handlers/error.js
@@ -6,6 +6,12 @@ var fs = require('fs');
 function errorPageHandler(err, req, res, next) {
     var ldp = req.app.locals.ldp;
 
+    // If the user specifies this function
+    // then, they can customize the error programmatically
+    if (ldp.errorHandler) {
+        return ldp.errorHandler(err, req, res, next);
+    }
+
     // If noErrorPages is set,
     // then use built-in express default error handler
     if (ldp.noErrorPages) {
@@ -18,7 +24,9 @@ function errorPageHandler(err, req, res, next) {
     var errorPage = ldp.errorPages + err.status.toString() + '.html';
     fs.readFile(errorPage, 'utf8', function(readErr, text) {
         if (readErr) {
-            return next();
+            return res
+                .status(err.status)
+                .send(err.message);
         }
 
         res.status(err.status);

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -16,6 +16,7 @@ var metadata = require('../metadata.js');
 var ns = require('../vocab/ns.js').ns;
 var utils = require('../utils.js');
 var subscription = require('../subscription.js');
+var HttpError = require('../http-error');
 
 var ldpVocab = require('../vocab/ldp.js');
 var turtleExtension = '.ttl';
@@ -123,10 +124,10 @@ function globHandler(req, res, next) {
     glob(filename, globOptions, function(err, matches) {
         if (err || matches.length === 0) {
             debug("GET/HEAD -- No files matching the pattern");
-            var globErr = new Error();
-            globErr.status = 404;
-            globErr.message = "No files matching glob pattern";
-            return next(globErr);
+            return next(new HttpError({
+                message: "No files matching glob pattern",
+                status: 404
+            }));
         }
 
         // Matches found
@@ -206,21 +207,22 @@ function parseLinkedData(req, res, next) {
     try {
         $rdf.parse(turtleData, resourceGraph, baseUri, 'text/turtle');
     } catch (err) {
-        debug("GET/HEAD -- Error parsing data: " + err);
-        var parseErr = new Error();
-        parseErr.status = 500;
-        parseErr.message = err.message;
-        return next(parseErr);
+
+        debug("GET/HEAD -- Error parsing data: " + err.message);
+        return next(new HttpError({
+            message: err.message,
+            status: 500
+        }));
     }
 
     // Graph to `accept` type
     $rdf.serialize(undefined, resourceGraph, null, accept, function(err, result) {
         if (result === undefined || err) {
             debug("GET/HEAD -- Serialization error: " + err);
-            var serializeErr = {};
-            serializeErr.status = 500;
-            serializeErr.message = err.message;
-            return next(serializeErr);
+            return next(new HttpError({
+                message: err.message,
+                status: 500
+            }));
         }
 
         return res

--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -8,6 +8,7 @@ var $rdf = require('rdflib');
 var debug = require('../logging').handlers;
 var utils = require('../utils.js');
 var subscription = require('../subscription.js');
+var HttpError = require('../http-error');
 
 function handler(req, res, next) {
     var ldp = req.app.locals.ldp;
@@ -45,11 +46,10 @@ function handler(req, res, next) {
             res.send("Patch applied OK\n");
         });
     } else {
-        var contentErr = new Error();
-        contentErr.status = 400;
-        contentErr.message = "Sorry unknowm patch content type: " +
-            patchContentType;
-        next(contentErr);
+        return next(new HttpError({
+            status: 400,
+            message: "Sorry unknown patch content type: " + patchContentType
+        }));
     }
 } // postOrPatch
 
@@ -63,10 +63,10 @@ function sparql (filename, targetURI, text, callback) {
 
     fs.readFile(filename, { encoding: 'utf8'}, function (err, dataIn) {
         if (err) {
-            return callback({
+            return callback(new HttpError({
                 status: 404,
                 message: "Patch: Original file read error:" + err
-            });
+            }));
         }
 
         debug("PATCH -- File read OK "+dataIn.length);
@@ -75,10 +75,10 @@ function sparql (filename, targetURI, text, callback) {
         try {
             $rdf.parse(dataIn, targetKB, targetURI, targetContentType);
         } catch(e) {
-            return callback({
+            return callback(new HttpError({
                 status: 500,
                 message: "Patch: Target " + targetContentType + " file syntax error:" + e
-            });
+            }));
         }
         debug("PATCH -- Target parsed OK ");
 
@@ -132,19 +132,19 @@ function sparqlUpdate(filename, targetURI, text, callback) {
         // Must parse relative to document's base address but patch doc should get diff URI
         patchObject = $rdf.sparqlUpdateParser(text, patchKB, patchURI);
     } catch(e) {
-        return callback({
+        return callback(new HttpError({
             status: 400,
             message: "Patch format syntax error:\n" + e + '\n'
-        });
+        }));
     }
     debug("PATCH -- reading target file ...");
 
     fs.readFile(filename, { encoding: 'utf8'}, function(err, dataIn) {
         if (err) {
-            return callback({
+            return callback(new HttpError({
                 status: 404,
                 message: "Patch: Original file read error:" + err
-            });
+            }));
         }
 
         debug("PATCH -- File read OK "+dataIn.length);
@@ -153,10 +153,10 @@ function sparqlUpdate(filename, targetURI, text, callback) {
         try {
             $rdf.parse(dataIn, targetKB, targetURI, targetContentType);
         } catch(e) {
-            return callback({
+            return callback(new HttpError({
                 status: 500,
                 message: "Patch: Target " + targetContentType + " file syntax error:" + e
-            });
+            }));
         }
         debug("PATCH -- Target parsed OK ");
 
@@ -165,10 +165,10 @@ function sparqlUpdate(filename, targetURI, text, callback) {
 
         targetKB.applyPatch(patchObject, target, function(err){
             if (err) {
-                return callback({
+                return callback(new HttpError({
                     status: 409,
-                    message: err
-                });
+                    message: err.message
+                }));
             }
             debug("PATCH -- Patched. Writeback URI base " + targetURI);
             var data = $rdf.serialize(target, targetKB, targetURI, targetContentType);
@@ -176,10 +176,10 @@ function sparqlUpdate(filename, targetURI, text, callback) {
 
             fs.writeFile(filename, data, {encoding: 'utf8'}, function(err, data) {
                 if (err) {
-                    return callback({
+                    return callback(new HttpError({
                         status: 500,
                         message: "Failed to write file back after patch: "+ err
-                    });
+                    }));
                 }
                 debug("PATCH -- applied OK (sync)");
                 return callback(null, patchKB);

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -13,6 +13,7 @@ var patch = require('./patch.js');
 
 var ldpVocab = require('../vocab/ldp.js');
 var rdfVocab = require('../vocab/rdf.js');
+var HttpError = require('../http-error');
 
 function handler(req, res, next) {
     var ldp = req.app.locals.ldp;
@@ -38,12 +39,12 @@ function handler(req, res, next) {
         contentType != 'application/nquads' &&
         contentType != 'application/n-quads') {
         debug("POST -- Invalid Content Type: " + contentType);
-        var contentErr = new Error();
-        contentErr.status = 415;
-        contentErr.message = "Invalid Content Type";
-        return next(contentErr);
-    }
 
+        return next(new HttpError({
+            status: 415,
+            message: "Invalid Content Type"
+        }));
+    }
 
     var containerPath = utils.uriToFilename(req.path, ldp.root);
     debug("POST -- Container path: " + containerPath);
@@ -52,10 +53,11 @@ function handler(req, res, next) {
     if (containerPath[containerPath.length - 1] != '/') {
         debug("POST -- Requested resource is not a container");
         res.set('Allow', 'GET,HEAD,PUT,DELETE');
-        var allowErr = new Error();
-        allowErr.status = 405;
-        allowErr.message = "Requested resource is not a container";
-        return next(allowErr);
+
+        return next(new HttpError({
+            status: 405,
+            message: "Requested resource is not a container"
+        }));
     }
 
     debug("POST -- Content Type: " + contentType);
@@ -72,10 +74,11 @@ function handler(req, res, next) {
     if (resourcePath === null) {
         ldp.releaseResourceUri(resourcePath);
         debug("POST -- URI already exists or in use");
-        var resourceErr = new Error();
-        resourceErr.status = 400;
-        resourceErr.message = "URI already exists or in use";
-        return next(resourceErr);
+
+        return next(new HttpError({
+            status: 400,
+            message: "URI already exists or in use"
+        }));
     }
 
     // Creating a graph and add the req text
@@ -97,7 +100,10 @@ function handler(req, res, next) {
         debug("POST -- Error parsing resource: " + parseErr);
         ldp.releaseResourceUri(resourcePath);
         parseErr.status = 400;
-        return next(parseErr);
+        return next(new HttpError({
+            status: 400,
+            message: "Error parsing resource"
+        }));
     }
 
     // Add header link to the resource
@@ -122,12 +128,10 @@ function handler(req, res, next) {
 
     function containerCallback(err) {
         if (err) {
-            debug("POST -- Error creating new container: " + err);
-            var createErr = new Error();
-            createErr.status = 500;
-            createErr.message = "Cannot create new container";
-            return next(createErr);
+            debug("POST -- Error creating new container: " + err.message);
+            return next(err);
         }
+
         debug("POST -- Created new container " + resourceBaseUri);
         res.set('Location', resourceBaseUri);
         return res.sendStatus(201);
@@ -135,11 +139,8 @@ function handler(req, res, next) {
 
     function resourceCallback(err) {
         if (err) {
-            debug("POST -- Error creating resource: " + err);
-            var createErr = new Error();
-            createErr.status = 500;
-            createErr.message = "Cannot create new container";
-            return next(createErr);
+            debug("POST -- Error creating resource: " + err.message);
+            return next(err);
         }
         res.set('Location', resourceBaseUri);
         return res.sendStatus(201);

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -99,7 +99,6 @@ function handler(req, res, next) {
     } catch (parseErr) {
         debug("POST -- Error parsing resource: " + parseErr);
         ldp.releaseResourceUri(resourcePath);
-        parseErr.status = 400;
         return next(new HttpError({
             status: 400,
             message: "Error parsing resource"

--- a/lib/header.js
+++ b/lib/header.js
@@ -7,6 +7,7 @@ var metadata = require('./metadata.js');
 var ldp = require('./ldp.js');
 var utils = require('./utils.js');
 var ldpVocab = require('./vocab/ldp.js');
+var HttpError = require('./http-error');
 
 function addLink(res, value, rel) {
     var oldLink = res.get('Link');
@@ -38,10 +39,11 @@ function linksHandler(req, res, next) {
     filename = path.join(filename, req.path);
     if (ldp.isMetadataFile(filename)) {
         debug.metadata("Trying to access metadata file as regular file.");
-        var metaErr = new Error();
-        metaErr.status = 404;
-        metaErr.message = "Trying to access metadata file as regular file";
-        return next(metaErr);
+
+        return next(new HttpError({
+            message: "Trying to access metadata file as regular file",
+            status: 404
+        }));
     }
     var fileMetadata = new metadata.Metadata();
     if (S(filename).endsWith('/')) {

--- a/lib/http-error.js
+++ b/lib/http-error.js
@@ -1,0 +1,8 @@
+module.exports = function HTTPError(opts) {
+  // Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = opts.message;
+  this.status = opts.status;
+};
+
+require('util').inherits(module.exports, Error);

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -343,7 +343,7 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
       debug.handlers("GET/HEAD -- Error serializing container: " + parseErr);
       return callback(new HttpError({
         status: 500,
-        message: parseErr
+        message: parseErr.message
       }));
     }
     return callback(null, turtleData);

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -181,7 +181,7 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
           } catch (dirErr) {
             return callback(new HttpError({
               status: err.code === 'ENOENT' ? 404 : 500,
-              message: dirErr
+              message: dirErr.message
             }));
           }
           return callback(null, metadataGraph);

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -15,6 +15,8 @@ var debug = require('./logging');
 
 var utils = require('./utils.js');
 var ns = require('./vocab/ns.js').ns;
+var HttpError = require('./http-error');
+
 var turtleExtension = '.ttl';
 
 module.exports = LDP;
@@ -71,6 +73,7 @@ function LDP(argv) {
       ldp.errorPages += '/';
     }
   }
+  ldp.errorHandler = argv.errorHandler;
 
   debug.settings("mount: " + ldp.mount);
   debug.settings("root: " + ldp.root);
@@ -85,10 +88,10 @@ function LDP(argv) {
 LDP.prototype.stat = function(file, callback) {
   fs.stat(file, function(err, stats) {
     if (err) {
-        return callback({
+        return callback(new HttpError({
           status: err.code === 'ENOENT' ? 404 : 500,
-          message: err
-        });
+          message: err.message
+        }));
       }
     return callback(null, stats);
   });
@@ -99,10 +102,10 @@ LDP.prototype.readFile = function (filename, callback) {
       'encoding': 'utf8'
   }, function(err, data) {
     if (err) {
-      return callback({
+      return callback(new HttpError({
         status: err.code === 'ENOENT' ? 404 : 500,
         message: "Can't read file: " + err
-      });
+      }));
     }
 
     return callback(null, data);
@@ -118,10 +121,10 @@ LDP.prototype.readContainerMeta = function (directory, callback) {
 
   ldp.readFile(directory + ldp.suffixMeta, function(err, data) {
     if (err) {
-      return callback({
+      return callback(new HttpError({
         status: err.status,
         message: 'Can\'t read metafile'
-      });
+      }));
     }
     return callback(null, data);
   });
@@ -145,7 +148,10 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
     fs.readdir(filename, function (err, files) {
       if (err) {
         debug.handlers("GET/HEAD -- Error reading files: " + err);
-        return callback({ status: 500, message: err });
+        return callback(new HttpError({
+          status: err.code === 'ENOENT' ? 404 : 500,
+          message: err.message
+        }));
       }
 
       debug.handlers("Files in directory: " + files);
@@ -173,7 +179,10 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
               fileBaseUri,
               'text/turtle');
           } catch (dirErr) {
-            return callback({ status: 500, message: dirErr });
+            return callback(new HttpError({
+              status: err.code === 'ENOENT' ? 404 : 500,
+              message: dirErr
+            }));
           }
           return callback(null, metadataGraph);
         });
@@ -186,14 +195,14 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
   function addFile(ldp, resourceGraph, baseUri, uri, container, file, callback) {
       // Skip .meta and .acl
       if (S(file).endsWith(ldp.suffixMeta) || S(file).endsWith(ldp.suffixAcl)) {
-        return callback();
+        return callback(null);
       }
 
       // Get file stats
       ldp.stat(container + file, function (err, stats) {
         if (err) {
           // File does not exist, skip
-          return callback();
+          return callback(null);
         }
 
         var fileSubject = file + (stats.isDirectory() ? '/' : '');
@@ -265,7 +274,7 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
             });
 
 
-          return callback();
+          return callback(null);
         });
       });
   }
@@ -278,7 +287,10 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
     $rdf.parse(containerData, resourceGraph, baseUri, 'text/turtle');
   } catch (err) {
     debug.handlers("GET/HEAD -- Error parsing data: " + err);
-    return callback({status:500, message: err});
+    return callback(new HttpError({
+      status: 500,
+      message: err.message
+    }));
   }
 
   async.waterfall([
@@ -329,7 +341,10 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
         'text/turtle');
     } catch (parseErr) {
       debug.handlers("GET/HEAD -- Error serializing container: " + parseErr);
-      return callback({status: 500, message: parseErr});
+      return callback(new HttpError({
+        status: 500,
+        message: parseErr
+      }));
     }
     return callback(null, turtleData);
   });
@@ -338,24 +353,30 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
 LDP.prototype.put = function (filePath, contents, callback) {
   // PUT requests not supported on containers. Use POST instead
   if (filePath[filePath.length - 1] === '/') {
-    return callback({
+    return callback(new HttpError({
       status: 409,
       message: "PUT to containers not supported. Use POST method instead"
-    });
+    }));
   }
 
   mkdirp(path.dirname(filePath), function (err) {
       if (err) {
           debug.handlers("PUT -- Error creating directory: " + err);
-          return callback({ status: 500, message: err });
+          return callback(new HTTPError({
+            status: err.code === 'ENOENT' ? 404 : 500,
+            message: err.message
+          }));
       }
       return fs.writeFile(filePath, contents, function() {
         if (err) {
           debug.handlers("PUT -- Error writing file: " + err);
-          return callback({ status: 500, message: err});
+          return callback(new HTTPError({
+            status: err.code === 'ENOENT' ? 404 : 500,
+            message: err.message
+          }));
         }
         // Success!
-        return callback();
+        return callback(null);
       });
   });
 };
@@ -365,10 +386,10 @@ LDP.prototype.get = function(filename, uri, includeBody, callback) {
     ldp.stat(filename, function(err, stats) {
         // File does not exist
         if (err) {
-            return callback({
+            return callback(new HttpError({
                 status: err.status,
                 message:"Can't read file: " + err.message
-            });
+            }));
         }
 
         // Just return, since resource exists
@@ -385,10 +406,7 @@ LDP.prototype.get = function(filename, uri, includeBody, callback) {
                 ldp.listContainer(filename, uri, metaFile, function (err, data) {
                     if (err) {
                         debug.handlers('GET/HEAD -- Read error:' + err.message);
-                        return callback({
-                            status: err.status,
-                            message: err.message
-                        });
+                        return callback(err);
                     }
                     // The ending `true`, specifies it is a container
                     return callback(null, data, true);
@@ -400,10 +418,7 @@ LDP.prototype.get = function(filename, uri, includeBody, callback) {
                 // Error when reading
                 if (err) {
                     debug.handlers('GET/HEAD -- Read error:' + err.message);
-                    return callback({
-                        status: err.status,
-                        message: err.message
-                    });
+                    return callback(err);
                 }
                 debug.handlers('GET/HEAD -- Read Ok. Bytes read: ' + data.length);
                 return callback(null, data);
@@ -416,7 +431,10 @@ LDP.prototype.delete = function(filename, callback) {
     var ldp = this;
     ldp.stat(filename, function(err, stats) {
         if (err) {
-            return callback({status:404, message: "Can't find file: " + err});
+            return callback(new HttpError({
+              status:404,
+              message: "Can't find file: " + err
+            }));
         }
 
         if (stats.isDirectory()) {
@@ -435,10 +453,10 @@ LDP.prototype.deleteContainerMetadata = function(directory, callback) {
     return fs.unlink(directory + this.suffixMeta, function(err, data) {
         if (err) {
             debug.container("DELETE -- unlink() error: " + err);
-            return callback({
+            return callback(new HttpError({
               status: err.code === 'ENOENT' ? 404 : 500,
               message: "Can't delete container: " + err
-            });
+            }));
         }
         return callback(null, data);
     });
@@ -448,10 +466,10 @@ LDP.prototype.deleteResource = function(filename, callback) {
     return fs.unlink(filename, function(err, data) {
         if (err) {
             debug.container("DELETE -- unlink() error: " + err);
-            return callback({
+            return callback(new HttpError({
               status: err.code === 'ENOENT' ? 404 : 500,
               message: "Can't delete container: " + err
-            });
+            }));
         }
         return callback(null, data);
     });
@@ -516,10 +534,13 @@ LDP.prototype.createNewResource = function(uri, resourcePath, resourceGraph, cal
         if (err) {
             debug.container("Error writing resource: " + err);
             ldp.releaseResourceUri(resourcePath);
-            return callback(err);
+            return callback(new HttpError({
+              message: "Cannot create new resource",
+              status: err.code === 'ENOENT' ? 404 : 500
+            }));
         }
 
-        return callback(err);
+        return callback(null);
     }
 };
 
@@ -531,7 +552,10 @@ LDP.prototype.createNewContainer = function (uri, containerPath, containerGraph,
         if (err) {
             debug.container("Error creating directory for new container: " + err);
             ldp.releaseResourceUri(containerPath);
-            return callback(err);
+            return callback(new HttpError({
+              message: "Cannot create new container",
+              status: err.code === 'ENOENT' ? 404 : 500
+            }));
         }
 
         var rawContainer = $rdf.serialize(
@@ -552,12 +576,15 @@ LDP.prototype.createNewContainer = function (uri, containerPath, containerGraph,
         if (err) {
             debug.container("Error writing container: " + err);
             ldp.releaseResourceUri(containerPath);
-            return callback(err);
+            return callback(new HttpError({
+              message: "Cannot create new container",
+              status: err.code === 'ENOENT' ? 404 : 500
+            }));
         }
 
         debug.container("Wrote container to " + containerPath);
         ldp.releaseResourceUri(containerPath);
-        return callback(err);
+        return callback(null);
 
     }
 };

--- a/lib/login.js
+++ b/lib/login.js
@@ -3,6 +3,7 @@
 
 var webid = require('webid');
 var debug = require('./logging').login;
+var HttpError = require('./http-error');
 
 function loginHandler(req, res, next) {
     var ldp = req.app.locals.ldp;
@@ -34,10 +35,10 @@ function loginHandler(req, res, next) {
         if (err) {
             debug("Error processing certificate: " + err);
             setEmptySession(req);
-            var authError = new Error();
-            authError.status = 403;
-            authError.message = err;
-            return next(authError);
+            return next(new HttpError({
+                status: 403,
+                message: err.message
+            }));
         }
         req.session.userId = result;
         req.session.identified = true;


### PR DESCRIPTION
- Introducing a custom error `HttpError` (`./lib/http-error.js`)
- Making every error an instance of `HttpError`
- Adding `ldp.errorHandler` in the options to enable custom error handlers
- Fixing little issues
- updated README
- added a custom error example
- now errors are not shown as `[object Object]` since instead of passing the error Object as a message, we pass the error String