### PR TITLE
Fixed wrong CType returned for the root acl resource.

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -19,12 +19,16 @@ var subscription = require('../subscription.js');
 var HttpError = require('../http-error');
 
 var ldpVocab = require('../vocab/ldp.js');
-var turtleExtension = '.ttl';
+var turtleExtensions = ['.ttl'];
 
 function get(req, res, next, includeBody) {
     var ldp = req.app.locals.ldp;
     var uri = utils.uriBase(req);
     var filename = utils.uriToFilename(req.path, ldp.root);
+
+    // Register acl and meta suffixes as turtle extensions
+    utils.pushIfNotExist(turtleExtensions, ldp.suffixAcl);
+    utils.pushIfNotExist(turtleExtensions, ldp.suffixMeta);
 
     // Add request to subscription service
     if (req.path.slice(-ldp.suffixChanges.length) ===
@@ -82,10 +86,7 @@ function get(req, res, next, includeBody) {
             res.set('content-type', contentType);
             debug('GET/HEAD -- content-type: ' + contentType);
 
-            // Consider acl and meta files text/turtle
-            if (path.extname(filename) === ldp.suffixAcl ||
-                path.basename(filename) === turtleExtension ||
-                path.basename(filename) === ldp.suffixMeta) {
+            if (utils.hasSuffix(filename, turtleExtensions)) {
                 contentType = 'text/turtle';
             }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,6 +50,15 @@ function pathBasename(fullpath) {
     return bname;
 }
 
+function hasSuffix(path, suffixes) {
+    for (var i in suffixes) {
+        if (path.indexOf(suffixes[i], path.length - suffixes[i].length) !== -1) {
+            return true;
+        }
+    }
+    return false;
+}
+
 function getResourceLink(filename, uri, base, suffix, otherSuffix) {
     var link = filenameToBaseUri(filename, uri, base);
     if (S(link).endsWith(suffix)) {
@@ -80,13 +89,23 @@ function shortTime() {
         '{Hours}:{Minutes}:{Seconds}.{Milliseconds}');
 }
 
+function pushIfNotExist (arr, item) {
+    if (arr.indexOf(item) == -1) {
+        arr.push(item);
+        return true;
+    }
+    return false;
+}
+
 exports.uriToFilename = uriToFilename;
 exports.uriToRelativeFilename = uriToRelativeFilename;
 exports.filenameToBaseUri = filenameToBaseUri;
 exports.uriAbs = uriAbs;
 exports.pathBasename = pathBasename;
 exports.uriBase = uriBase;
+exports.hasSuffix = hasSuffix;
 exports.getResourceLink = getResourceLink;
 exports.formatDateTime = formatDateTime;
 exports.timestamp = timestamp;
 exports.shortTime = shortTime;
+exports.pushIfNotExist = pushIfNotExist;

--- a/test/acl.js
+++ b/test/acl.js
@@ -125,6 +125,18 @@ describe('ACL HTTP', function() {
                 done();
             });
         });
+        it("Should return text/turtle for the acl file", function(done) {
+            var options = createOptions(testDirAclFile, 'user1');
+            options.headers = {
+                accept: 'text/turtle'
+            };
+            request.get(options, function(error, response, body) {
+                assert.equal(error, null);
+                assert.equal(response.statusCode, 200);
+                assert.match(response.headers['content-type'], /text\/turtle/);
+                done();
+            });
+        });
         it("Should create test file", function(done) {
             var options = createOptions(abcFile, 'user1');
             options.headers = {
@@ -980,7 +992,7 @@ describe('ACL HTTP', function() {
             // });
         // });
     });
-    
+
     describe("Cleaup", function() {
         it("should remove all files and dirs created", function(done) {
             try {


### PR DESCRIPTION
This PR introduces the following fixes:
 * register acl and meta suffixes as Turtle extensions
 * adds missing test to check content-type header for a root acl resource
 * adds helper function to push items to an array if they don't exist
 * adds helper function to check if a given path contains an extension (out of a list of extensions)