### PR TITLE
Adding web socket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Options:
    --no-live               Disable live support through WebSockets
    -sA, --suffix-acl       Suffix for acl files (default: '.acl')
    -sM, --suffix-meta      Suffix for metadata files (default: '.meta')
-   -sC, --suffix-changes   Suffix for acl files (default: '.changes')
    -sE, --suffix-sse       Suffix for SSE files (default: '.events')
 
 ```
@@ -83,7 +82,6 @@ In case the `settings` is not passed, then it will start with the following defa
   mount: '/', // Where to mount Linked Data Platform
   webid: false, // Enable WebID+TLS authentication
   suffixAcl: '.acl', // Suffix for acl files
-  suffixChanges: '.changes', // Suffix for acl files
   suffixSSE: '.events', // Suffix for SSE files
   proxy: false, // Where to mount the proxy
   errorHandler: false, // function(err, req, res, next) to have a custom error handler

--- a/bin/ldnode.js
+++ b/bin/ldnode.js
@@ -129,6 +129,7 @@ try {
   app = ldnode.createServer(argv);
 } catch(e) {
   console.log(e.message);
+  console.log(e.stack)
   return 1;
 }
 app.listen(argv.port, function() {

--- a/bin/ldnode.js
+++ b/bin/ldnode.js
@@ -74,11 +74,6 @@ var argv = require('nomnom')
     help: 'Suffix for metadata files (default: \'.meta\')',
     abbr: 'sM'
   })
-  .option('suffixChanges', {
-    full: 'suffix-changes',
-    help: 'Suffix for acl files (default: \'.changes\')',
-    abbr: 'sC'
-  })
   .option('suffixSSE', {
     full: 'suffix-sse',
     help: 'Suffix for SSE files (default: \'.events\')',

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -1,7 +1,6 @@
 module.exports = createApp;
 
 var express = require('express');
-var expressWs = require('express-ws');
 var session = require('express-session');
 var uuid = require('node-uuid');
 var cors = require('cors');
@@ -22,19 +21,6 @@ var corsSettings = cors({
     maxAge: 1728000,
     origin: true
 });
-
-function ws (app) {
-    expressWs(app);
-    app.mountpath = ''; //  needs to be set for addSocketRoute aka .ws()
-    // was options.pathFilter
-    app.ws('/', function(socket, res) {
-        debug.subscription("incoming on " + socket.path);
-        socket.on('message', function(msg) {
-            debug.subscription("message = " + msg);
-            // subscribeToChanges(socket, res);
-        });
-    });
-}
 
 function createApp (argv) {
     var ldp = new LDP(argv);
@@ -57,11 +43,6 @@ function createApp (argv) {
 
     // Setting up routes
     app.use('/', LdpMiddleware(corsSettings));
-
-    // Setup Express app
-    if (ldp.live) {
-        ws(app);
-    }
 
     return app;
 }

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -70,7 +70,8 @@ function createServer(argv) {
 
     // Setup Express app
     if (ldp.live) {
-        SolidWs(server, app)
+        var solidWs = SolidWs(server, ldpApp)
+        ldpApp.locals.ldp.live = solidWs.publish.bind(solidWs)
     }
 
     return server

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -3,6 +3,8 @@ module.exports = createServer;
 var express = require('express');
 var fs = require('fs');
 var https = require('https');
+var http = require('http');
+var SolidWs = require('solid-ws');
 
 var debug = require('./debug');
 var createApp = require('./create-app');
@@ -22,6 +24,8 @@ function createServer(argv) {
 
     app.use(mount, ldpApp);
     debug.settings('mount: ' + mount);
+
+    var server = http.createServer(app);
 
     if (ldp && (ldp.webid || argv.key || argv.cert) ) {
         debug.settings("SSL Private Key path: " + argv.key);
@@ -61,8 +65,13 @@ function createServer(argv) {
 
         debug.settings("Certificate: " + credentials.cert);
 
-        return https.createServer(credentials, app);
+        server = https.createServer(credentials, app);
     }
 
-    return app;
+    // Setup Express app
+    if (ldp.live) {
+        SolidWs(server, app)
+    }
+
+    return server
 }

--- a/lib/handlers/delete.js
+++ b/lib/handlers/delete.js
@@ -20,7 +20,8 @@ function handler(req, res, next) {
         }
 
         debug("DELETE -- Ok.");
-        if (ldp.live) ldp.live(req.originalUrl)
+        if (ldp.live) ldp.live(utils.uriAbs(req) + path.basename(req.originalUrl))
+        if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
         return res.sendStatus(200);
     });
 

--- a/lib/handlers/delete.js
+++ b/lib/handlers/delete.js
@@ -20,8 +20,8 @@ function handler(req, res, next) {
         }
 
         debug("DELETE -- Ok.");
+        if (ldp.live) ldp.live(req.originalUrl)
         return res.sendStatus(200);
-
     });
 
 }

--- a/lib/handlers/delete.js
+++ b/lib/handlers/delete.js
@@ -20,9 +20,9 @@ function handler(req, res, next) {
         }
 
         debug("DELETE -- Ok.");
-        if (ldp.live) ldp.live(utils.uriAbs(req) + path.basename(req.originalUrl))
-        if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
-        return res.sendStatus(200);
+
+        res.sendStatus(200);
+        return next();
     });
 
 }

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -42,7 +42,7 @@ function get(req, res, next, includeBody) {
     if (ldp.live) {
         // Note not yet in
         // http://www.iana.org/assignments/link-relations/link-relations.xhtml
-        header.addLink(res, req.originalUrl + ldp.suffixChanges, 'changes');
+        // header.addLink(res, req.originalUrl + ldp.suffixChanges, 'changes');
         // res.header('Link' , '' + req.path + ldp.suffixSSE + ' ; rel=events' );
         // overwrites the pevious
         res.header('Updates-Via', utils.uriBase(req));

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -20,17 +20,12 @@ var HttpError = require('../http-error');
 
 var ldpVocab = require('../vocab/ldp.js');
 
-function get(req, res, next, includeBody) {
+function get(req, res, next) {
     var ldp = req.app.locals.ldp;
     var uri = utils.uriBase(req);
     var filename = utils.uriToFilename(req.path, ldp.root);
 
-    // // Add request to subscription service
-    // if (req.path.slice(-ldp.suffixChanges.length) ===
-    //     ldp.suffixChanges) {
-    //     debug("GET -- Subscribed to " + req.originalUrl);
-    //     return subscription.subscribeToChanges(req, res);
-    // }
+    var includeBody = req.method === 'GET'
 
     // Parse accept mime types into a priority (q) ordered array
     res.acceptTypes = header.negotiateContentType(req) || 'text/turtle';
@@ -40,19 +35,10 @@ function get(req, res, next, includeBody) {
 
     // Set live updates
     if (ldp.live) {
-        // Note not yet in
-        // http://www.iana.org/assignments/link-relations/link-relations.xhtml
-        // header.addLink(res, req.originalUrl + ldp.suffixChanges, 'changes');
-        // res.header('Link' , '' + req.path + ldp.suffixSSE + ' ; rel=events' );
-        // overwrites the pevious
         res.header('Updates-Via', utils.uriBase(req));
     }
 
-    if (includeBody) {
-        debug('GET -- ' + req.originalUrl);
-    } else {
-        debug('HEAD -- ' + req.originalUrl);
-    }
+    debug(req.method + ' -- ' + req.originalUrl);
 
     // Get resource or container
     ldp.get(filename, uri, includeBody, function(err, data, container) {
@@ -72,7 +58,8 @@ function get(req, res, next, includeBody) {
         // Just return that file exists
         // data is of `typeof 'string'` if file is empty, but exists!
         if (data === undefined) {
-            return res.sendStatus(200);
+            res.sendStatus(200);
+            return next();
         }
 
         // Container/resource retrieved
@@ -87,9 +74,10 @@ function get(req, res, next, includeBody) {
 
             // if data is not text/turtle, just send it
             if (contentType !== 'text/turtle') {
-                return res
+                res
                     .status(200)
                     .send(data);
+                return next();
             }
         }
 
@@ -192,9 +180,10 @@ function parseLinkedData(req, res, next) {
         accept === 'text/n3' ||
         accept === 'application/turtle' ||
         accept === 'application/n3') {
-        return res.status(200)
+        res.status(200)
             .set('content-type', accept)
             .send(turtleData);
+        return next();
     }
 
     //Handle other file types
@@ -219,21 +208,13 @@ function parseLinkedData(req, res, next) {
                 status: 500
             }));
         }
-
-        return res
+        res
             .status(200)
             .set('content-type', accept)
             .send(result);
+
+        return next();
     });
 }
 
-function getHandler(req, res, next) {
-    get(req, res, next, true);
-}
-
-function headHandler(req, res, next) {
-    get(req, res, next, false);
-}
-
-exports.handler = getHandler;
-exports.headHandler = headHandler;
+exports.handler = get;

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -25,12 +25,12 @@ function get(req, res, next, includeBody) {
     var uri = utils.uriBase(req);
     var filename = utils.uriToFilename(req.path, ldp.root);
 
-    // Add request to subscription service
-    if (req.path.slice(-ldp.suffixChanges.length) ===
-        ldp.suffixChanges) {
-        debug("GET -- Subscribed to " + req.originalUrl);
-        return subscription.subscribeToChanges(req, res);
-    }
+    // // Add request to subscription service
+    // if (req.path.slice(-ldp.suffixChanges.length) ===
+    //     ldp.suffixChanges) {
+    //     debug("GET -- Subscribed to " + req.originalUrl);
+    //     return subscription.subscribeToChanges(req, res);
+    // }
 
     // Parse accept mime types into a priority (q) ordered array
     res.acceptTypes = header.negotiateContentType(req) || 'text/turtle';
@@ -45,7 +45,7 @@ function get(req, res, next, includeBody) {
         header.addLink(res, req.originalUrl + ldp.suffixChanges, 'changes');
         // res.header('Link' , '' + req.path + ldp.suffixSSE + ' ; rel=events' );
         // overwrites the pevious
-        res.header('Updates-Via', req.originalUrl + ldp.suffixChanges);
+        res.header('Updates-Via', utils.uriBase(req));
     }
 
     if (includeBody) {

--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -40,7 +40,8 @@ function handler(req, res, next) {
             }
 
             if (ldp.live) {
-                subscription.publishDelta(req, res, patchKB, targetURI);
+                ldp.live(req.originalUrl)
+                // subscription.publishDelta(req, res, patchKB, targetURI);
             }
             debug("PATCH -- applied OK (sync)");
             res.send("Patch applied OK\n");

--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -30,6 +30,7 @@ function handler(req, res, next) {
                 next(err);
             }
 
+            if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
             return res.json(result);
         });
     } else

--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -27,11 +27,11 @@ function handler(req, res, next) {
     if (patchContentType === 'application/sparql') {
         sparql(filename, targetURI, req.text, function(err, result) {
             if (err) {
-                next(err);
+                return next(err);
             }
 
-            if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
-            return res.json(result);
+            res.json(result);
+            return next();
         });
     } else
     if (patchContentType === 'application/sparql-update') {
@@ -40,10 +40,10 @@ function handler(req, res, next) {
                 return next(err);
             }
 
-            if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
             // subscription.publishDelta(req, res, patchKB, targetURI);
             debug("PATCH -- applied OK (sync)");
             res.send("Patch applied OK\n");
+            return next()
         });
     } else {
         return next(new HttpError({

--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -39,10 +39,8 @@ function handler(req, res, next) {
                 return next(err);
             }
 
-            if (ldp.live) {
-                ldp.live(req.originalUrl)
-                // subscription.publishDelta(req, res, patchKB, targetURI);
-            }
+            if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
+            // subscription.publishDelta(req, res, patchKB, targetURI);
             debug("PATCH -- applied OK (sync)");
             res.send("Patch applied OK\n");
         });

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -133,6 +133,7 @@ function handler(req, res, next) {
 
         debug("POST -- Created new container " + resourceBaseUri);
         res.set('Location', resourceBaseUri);
+        if (ldp.live) ldp.live(utils.uriAbs(req) + path.basename(req.originalUrl))
         return res.sendStatus(201);
     }
 
@@ -142,6 +143,8 @@ function handler(req, res, next) {
             return next(err);
         }
         res.set('Location', resourceBaseUri);
+        if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
+            if (ldp.live) ldp.live(utils.uriAbs(req) + path.basename(req.originalUrl))
         return res.sendStatus(201);
     }
 }

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -22,13 +22,13 @@ function handler(req, res, next) {
     // Handle SPARQL query
     if (contentType === 'application/sparql') {
         debug("POST -- Handling sparql query");
-        return patch.handler(req, res);
+        return patch.handler(req, res, next);
     }
 
     // Handle SPARQL-update query
     if (contentType === 'application/sparql-update') {
         debug("POST -- Handling sparql-update query");
-        return patch.handler(req, res);
+        return patch.handler(req, res, next);
     }
 
     // Error on invalid content-type
@@ -133,8 +133,8 @@ function handler(req, res, next) {
 
         debug("POST -- Created new container " + resourceBaseUri);
         res.set('Location', resourceBaseUri);
-        if (ldp.live) ldp.live(utils.uriAbs(req) + path.basename(req.originalUrl))
-        return res.sendStatus(201);
+        res.sendStatus(201);
+        return next();
     }
 
     function resourceCallback(err) {
@@ -143,9 +143,8 @@ function handler(req, res, next) {
             return next(err);
         }
         res.set('Location', resourceBaseUri);
-        if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
-            if (ldp.live) ldp.live(utils.uriAbs(req) + path.basename(req.originalUrl))
-        return res.sendStatus(201);
+        res.sendStatus(201);
+        return next();
     }
 }
 

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -27,8 +27,8 @@ function handler(req, res, next) {
 
         debug("PUT -- Write Ok. Bytes written: " + req.text.length);
 
-        if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
-        return res.sendStatus(201);
+        res.sendStatus(201);
+        return next();
     });
 }
 

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -4,6 +4,7 @@
 var mime = require('mime');
 var path = require('path');
 var $rdf = require('rdflib');
+var path = require('path')
 
 var debug = require('../debug').handlers;
 var utils = require('../utils.js');
@@ -26,7 +27,7 @@ function handler(req, res, next) {
 
         debug("PUT -- Write Ok. Bytes written: " + req.text.length);
 
-        if (ldp.live) ldp.live(req.originalUrl)
+        if (ldp.live) ldp.live(utils.uriAbs(req) + req.originalUrl)
         return res.sendStatus(201);
     });
 }

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -25,6 +25,8 @@ function handler(req, res, next) {
         }
 
         debug("PUT -- Write Ok. Bytes written: " + req.text.length);
+
+        if (ldp.live) ldp.live(req.originalUrl)
         return res.sendStatus(201);
     });
 }

--- a/lib/ldp-middleware.js
+++ b/lib/ldp-middleware.js
@@ -45,7 +45,6 @@ function LdpMiddleware (corsSettings) {
 
     //ACL handlers
     router.get("/*", acl.allowReadHandler);
-    router.head("/*", acl.allowReadHandler);
     router.post("/*", acl.allowAppendThenWriteHandler);
     router.patch("/*", acl.allowAppendThenWriteHandler);
     router.put("/*", acl.allowAppendThenWriteHandler);
@@ -59,7 +58,6 @@ function LdpMiddleware (corsSettings) {
 
     // HTTP methods handlers
     router.get('/*', getHandler.handler);
-    router.head('/*', getHandler.headHandler);
     router.put('/*', putHandler.handler);
     router.delete('/*', deleteHandler.handler);
     router.post('/*', postHandler.handler);

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -43,9 +43,8 @@ function LDP(argv) {
   ldp.leavePatchConnectionOpen = false;
   ldp.suffixAcl = argv.suffixAcl || ".acl";
   ldp.suffixMeta = argv.suffixMeta || ".meta";
-  ldp.suffixChanges = argv.suffixChanges || '.changes';
   ldp.suffixSSE = argv.suffixSSE || '.events';
-  ldp.turtleExtensions = ['.ttl', ldp.suffixAcl, ldp.suffixMeta, ldp.suffixChanges, ldp.suffixSSE]
+  ldp.turtleExtensions = ['.ttl', ldp.suffixAcl, ldp.suffixMeta, ldp.suffixSSE]
 
   ldp.proxy = argv.proxy;
 

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -51,8 +51,6 @@ function LDP(argv) {
 
   // Cache of usedURIs
   ldp.usedURIs = {};
-  ldp.SSEsubscriptions = {};
-  ldp.subscriptions = {};
 
   // Error pages folder
   ldp.noErrorPages = argv.noErrorPages;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "redis": "^0.12.1",
     "request": "^2.58.0",
     "response-time": "^2.3.1",
-    "solid-ws": "^0.1.0",
+    "solid-ws": "^0.1.4",
     "string": "^3.3.0",
     "webid": "^0.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "redis": "^0.12.1",
     "request": "^2.58.0",
     "response-time": "^2.3.1",
+    "solid-ws": "^0.1.0",
     "string": "^3.3.0",
     "webid": "^0.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-uuid": "^1.4.3",
     "nomnom": "^1.8.1",
     "raw-body": "^2.1.2",
-    "rdflib": "^0.2.8",
+    "rdflib": "^0.2.9",
     "redis": "^0.12.1",
     "request": "^2.58.0",
     "response-time": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "redis": "^0.12.1",
     "request": "^2.58.0",
     "response-time": "^2.3.1",
-    "solid-ws": "^0.1.4",
+    "solid-ws": "^0.1.5",
     "string": "^3.3.0",
     "webid": "^0.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "async": "^1.3.0",
     "cors": "^2.7.1",
     "debug": "^2.2.0",
-    "express": "^4.13.1",
+    "express": "^4.13.3",
     "express-session": "^1.11.3",
     "fs-extra": "^0.21.0",
     "glob": "^5.0.13",
@@ -46,7 +46,7 @@
     "redis": "^0.12.1",
     "request": "^2.58.0",
     "response-time": "^2.3.1",
-    "solid-ws": "^0.1.5",
+    "solid-ws": "^0.2.0",
     "string": "^3.3.0",
     "webid": "^0.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "debug": "^2.2.0",
     "express": "^4.13.1",
     "express-session": "^1.11.3",
-    "express-ws": "^0.2.6",
     "fs-extra": "^0.21.0",
     "glob": "^5.0.13",
     "http-delayed-response": "0.0.4",


### PR DESCRIPTION
It uses [solid-ws](http://github.com/nicola/solid-ws)

- [x] I cleaned some code
- [x] Removed the difference between GET/HEAD since HEAD fallback on GET by default
- [x] Support on websocket is self-contained in the library solid-ws
- [x] Added `next` to every res.send