### PR TITLE
refactoring get to fix #138

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -1,5 +1,5 @@
 /*jslint node: true*/
-"use strict";
+'use strict';
 
 var mime = require('mime');
 var fs = require('fs');
@@ -8,6 +8,7 @@ var path = require('path');
 var $rdf = require('rdflib');
 var S = require('string');
 var async = require('async');
+var Negotiator = require('negotiator')
 
 var debug = require('../debug').handlers;
 var acl = require('../acl.js');
@@ -15,21 +16,32 @@ var header = require('../header.js');
 var metadata = require('../metadata.js');
 var ns = require('../vocab/ns.js').ns;
 var utils = require('../utils.js');
+var translate = require('../utils.js').translate;
 var HttpError = require('../http-error');
+var parse = require('../utils.js').parse;
 
 var ldpVocab = require('../vocab/ldp.js');
 
-function get(req, res, next) {
-    var ldp = req.app.locals.ldp;
-    var uri = utils.uriBase(req);
-    var filename = utils.uriToFilename(req.path, ldp.root);
+var RDFs = [
+    'text/turtle',
+    'application/n3',
+    'application/nquads',
+    'application/n-quads',
+    'text/n3',
+    'application/rdf+xml',
+    'application/ld+json',
+    'application/x-turtle'
+]
 
+function get (req, res, next) {
+    var ldp = req.app.locals.ldp;
     var includeBody = req.method === 'GET'
 
-    // Parse accept mime types into a priority (q) ordered array
-    res.acceptTypes = header.negotiateContentType(req) || 'text/turtle';
+    var negotiator = new Negotiator(req)
+    var requestedType = negotiator.mediaType()
+    var possibleRDFType = negotiator.mediaType(RDFs)
 
-    // Set headers
+    var baseUri = utils.uriBase(req);
     res.header('MS-Author-Via', 'SPARQL');
 
     // Set live updates
@@ -37,62 +49,73 @@ function get(req, res, next) {
         res.header('Updates-Via', utils.uriBase(req));
     }
 
-    debug(req.method + ' -- ' + req.originalUrl);
+    console.log('METHOD', req.method)
+    debug(req.method + ' requesting -- ' + req.originalUrl);
 
     // Get resource or container
-    ldp.get(filename, uri, includeBody, function(err, data, container) {
+    ldp.get(req.path, baseUri, includeBody, possibleRDFType,
+        function (err, stream, contentType, container) {
 
-        // This should be implemented in LDP.prototype.get
-        if (err && err.status === 404 && glob.hasMagic(filename)) {
-            debug("GET/HEAD -- Glob request");
+        console.log('file appears to be', contentType)
+        // use globHandler if magic is detected
+        if (err && err.status === 404 && glob.hasMagic(req.path)) {
+            debug(req.method + ' -- Glob request');
             return globHandler(req, res, next);
         }
 
-
+        // Handle error
         if (err) {
-            debug('GET/HEAD -- Read error: ' + err.status + ' ' + err.message);
+            debug(req.method + ' -- Error: ' + err.status + ' ' + err.message);
             return next(err);
         }
 
-        // Just return that file exists
-        // data is of `typeof 'string'` if file is empty, but exists!
-        if (data === undefined) {
-            res.sendStatus(200);
-            return next();
+        // Till here it must exist
+        if (!includeBody) {
+            debug('HEAD only -- ' + req.originalUrl);
+            return res.send(200)
         }
 
-        // Container/resource retrieved
-        if (!container) {
-            var contentType = mime.lookup(filename);
-            res.set('content-type', contentType);
-            debug('GET/HEAD -- content-type: ' + contentType);
-
-            if (utils.hasSuffix(filename, ldp.turtleExtensions)) {
-                contentType = 'text/turtle';
-            }
-
-            // if data is not text/turtle, just send it
-            if (contentType !== 'text/turtle') {
-                return res
-                    .status(200)
-                    .sendFile(path.resolve(filename));
-            }
-        }
-
-        // redirect to file browser if we got text/html with highest priority
+        // Handle skin
         if (container &&
-            res.acceptTypes.indexOf('text/html') === 0 &&
+            requestedType.indexOf('text/html') === 0 &&
             ldp.skin) {
-            return res.redirect(303, ldp.skin + req.protocol + '/' + req.get('host') + req.originalUrl);
+            var address = req.protocol + '/' + req.get('host') + req.originalUrl;
+            return res.redirect(303, ldp.skin + address);
         }
 
-        // TODO this should be added as a middleware in the routes
-        res.locals.turtleData = data;
-        return parseLinkedData(req, res, next);
+        // If request accepts the content-type we found
+        if (negotiator.mediaType([contentType])) {
+            debug('GET -- ' + req.originalUrl + ' no translation ' + contentType);
+            res.setHeader('content-type', contentType)
+            return stream.pipe(res)
+        }
+
+        // If it is not in our RDFs we can't even translate,
+        // Sorry, we can't help
+        if (!possibleRDFType) {
+            var err = new Error('Cannot server your type')
+            err.status = 406
+            return next(err);
+        }
+
+
+        // Translate from the contentType found to the possibleRDFType desired
+        translate(stream, baseUri, contentType, possibleRDFType, function (err, data) {
+            if (err) {
+                debug('GET ERROR translating: ' + req.originalUrl + ' ' + contentType + ' -> ' + possibleRDFType +' -- ' + 500 + err.message);
+                return next(new HttpError({
+                    message: err.message,
+                    status: 500
+                }))
+            }
+            debug('GET -- ' + req.originalUrl + ' translating ' + contentType + ' -> ' + possibleRDFType);
+            res.setHeader('Content-Type', possibleRDFType)
+            return res.send(data);
+        });
     });
 }
 
-function globHandler(req, res, next) {
+function globHandler (req, res, next) {
     var ldp = req.app.locals.ldp;
     var filename = utils.uriToFilename(req.path, ldp.root);
     var uri = utils.uriBase(req);
@@ -102,11 +125,11 @@ function globHandler(req, res, next) {
         nobrace: true
     };
 
-    glob(filename, globOptions, function(err, matches) {
+    glob(filename, globOptions, function (err, matches) {
         if (err || matches.length === 0) {
-            debug("GET/HEAD -- No files matching the pattern");
+            debug('GET/HEAD -- No files matching the pattern');
             return next(new HttpError({
-                message: "No files matching glob pattern",
+                message: 'No files matching glob pattern',
                 status: 404
             }));
         }
@@ -114,15 +137,15 @@ function globHandler(req, res, next) {
         // Matches found
         var globGraph = $rdf.graph();
 
-        async.each(matches, function(match, done) {
+        async.each(matches, function (match, done) {
             var baseUri = utils.filenameToBaseUri(match, uri, ldp.root);
-            fs.readFile(match, {encoding: "utf8"}, function(err, fileData) {
+            fs.readFile(match, {encoding: 'utf8'}, function (err, fileData) {
                 if (err) {
                     debug('GET -- Error in globHandler' + err);
                     return done(null);
                 }
                 aclAllow(match, req, res, function (allowed) {
-                    if (!S(match).endsWith(".ttl") || !allowed) {
+                    if (!S(match).endsWith('.ttl') || !allowed) {
                         return done(null);
                     }
                     try {
@@ -144,13 +167,13 @@ function globHandler(req, res, next) {
                 null,
                 'text/turtle');
             // TODO this should be added as a middleware in the routes
-            res.locals.turtleData = data;
-            return parseLinkedData(req, res, next);
+            res.setHeader('Content-Type', 'text/turtle')
+            res.send(data)
         });
     });
 }
 
-function aclAllow(match, req, res, callback) {
+function aclAllow (match, req, res, callback) {
     var ldp = req.app.locals.ldp;
 
     if (!ldp.webid) {
@@ -159,59 +182,8 @@ function aclAllow(match, req, res, callback) {
 
     var relativePath = '/' + path.relative(ldp.root, match);
     res.locals.path = relativePath;
-    acl.allow("Read", req, res, function(err) {
+    acl.allow('Read', req, res, function (err) {
         callback(err);
-    });
-}
-
-function parseLinkedData(req, res, next) {
-    var ldp = req.app.locals.ldp;
-    var filename = utils.uriToFilename(req.path, ldp.root);
-    var uri = utils.uriBase(req);
-    var turtleData = res.locals.turtleData;
-
-    var accept = header.parseAcceptRDFHeader(req) || 'text/turtle';
-    var baseUri = utils.filenameToBaseUri(filename, uri, ldp.root);
-
-    // Handle Turtle Accept header
-    if (accept === 'text/turtle' ||
-        accept === 'text/n3' ||
-        accept === 'application/turtle' ||
-        accept === 'application/n3') {
-        res.status(200)
-            .set('content-type', accept)
-            .send(turtleData);
-        return next();
-    }
-
-    //Handle other file types
-    var resourceGraph = $rdf.graph();
-    try {
-        $rdf.parse(turtleData, resourceGraph, baseUri, 'text/turtle');
-    } catch (err) {
-
-        debug("GET/HEAD -- Error parsing data: " + err.message);
-        return next(new HttpError({
-            message: err.message,
-            status: 500
-        }));
-    }
-
-    // Graph to `accept` type
-    $rdf.serialize(undefined, resourceGraph, null, accept, function(err, result) {
-        if (result === undefined || err) {
-            debug("GET/HEAD -- Serialization error: " + err);
-            return next(new HttpError({
-                message: err.message,
-                status: 500
-            }));
-        }
-        res
-            .status(200)
-            .set('content-type', accept)
-            .send(result);
-
-        return next();
     });
 }
 

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -49,14 +49,12 @@ function get (req, res, next) {
         res.header('Updates-Via', utils.uriBase(req));
     }
 
-    console.log('METHOD', req.method)
     debug(req.method + ' requesting -- ' + req.originalUrl);
 
     // Get resource or container
     ldp.get(req.path, baseUri, includeBody, possibleRDFType,
         function (err, stream, contentType, container) {
 
-        console.log('file appears to be', contentType)
         // use globHandler if magic is detected
         if (err && err.status === 404 && glob.hasMagic(req.path)) {
             debug(req.method + ' -- Glob request');

--- a/lib/header.js
+++ b/lib/header.js
@@ -2,7 +2,6 @@ var li = require('li');
 
 var path = require('path');
 var S = require('string');
-var Negotiator = require('negotiator');
 var metadata = require('./metadata.js');
 var ldp = require('./ldp.js');
 var utils = require('./utils.js');
@@ -88,45 +87,7 @@ function parseMetadataFromHeader(linkHeader) {
 }
 
 
-// Returns an array containing mime types from Accept header, ordered by priority
-// If no Accept value, serve turtle by default
-function negotiateContentType(req) {
-    var negotiator = new Negotiator(req);
-    return negotiator.mediaTypes();
-}
-
-function parseAcceptRDFHeader(req) {
-    var acceptFinalValue;
-    var acceptHeader = negotiateContentType(req);
-    if (!acceptHeader || acceptHeader.length === 0) {
-        acceptFinalValue = undefined;
-    } else {
-        for (var i in acceptHeader) {
-            switch (acceptHeader[i]) {
-                case 'text/turtle':
-                case 'application/x-turtle':
-                case 'text/n3':
-                case 'application/rdf+xml':
-                case 'application/n3':
-                case 'application/ld+json':
-                case 'application/nquads':
-                case 'application/n-quads':
-                    acceptFinalValue = acceptHeader[i];
-                    break;
-                default:
-                    acceptFinalValue = undefined;
-            }
-            if (acceptFinalValue !== undefined) {
-                break;
-            }
-        }
-    }
-    return acceptFinalValue;
-}
-
 module.exports.addLink = addLink;
 module.exports.addLinks = addLinks;
 module.exports.parseMetadataFromHeader = parseMetadataFromHeader;
-module.exports.parseAcceptRDFHeader = parseAcceptRDFHeader;
 module.exports.linksHandler = linksHandler;
-module.exports.negotiateContentType = negotiateContentType;

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -1,5 +1,5 @@
 module.exports = LDP;
-
+var mime = require('mime')
 var path = require('path');
 var regexp = require('node-regexp');
 var S = require('string');
@@ -10,9 +10,10 @@ var fs = require('fs');
 var mkdirp = require('fs-extra').mkdirp;
 var uuid = require('node-uuid');
 var debug = require('./debug');
-var utils = require('./utils.js');
-var ns = require('./vocab/ns.js').ns;
+var utils = require('./utils');
+var ns = require('./vocab/ns').ns;
 var HttpError = require('./http-error');
+var stringToStream = require('./utils').stringToStream
 var turtleExtension = '.ttl'
 
 function LDP(argv) {
@@ -73,6 +74,10 @@ LDP.prototype.stat = function(file, callback) {
   });
 };
 
+LDP.prototype.createReadStream = function (filename) {
+  return fs.createReadStream(filename, { 'encoding': 'utf8' })
+}
+
 LDP.prototype.readFile = function (filename, callback) {
   fs.readFile(filename, {
       'encoding': 'utf8'
@@ -106,7 +111,7 @@ LDP.prototype.readContainerMeta = function (directory, callback) {
   });
 };
 
-LDP.prototype.listContainer = function (filename, uri, containerData, callback) {
+LDP.prototype.listContainer = function (filename, uri, containerData, contentType, callback) {
   function addStats (resourceGraph, baseUri, stats) {
     resourceGraph.add(
       resourceGraph.sym(baseUri),
@@ -120,10 +125,10 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
   }
 
   function readdir(filename, callback) {
-    debug.handlers("GET/HEAD -- Reading directory");
+    debug.handlers("GET -- Reading directory");
     fs.readdir(filename, function (err, files) {
       if (err) {
-        debug.handlers("GET/HEAD -- Error reading files: " + err);
+        debug.handlers("GET -- Error reading files: " + err);
         return callback(new HttpError({
           status: err.code === 'ENOENT' ? 404 : 500,
           message: err.message
@@ -257,7 +262,7 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
   try {
     $rdf.parse(containerData, resourceGraph, baseUri, 'text/turtle');
   } catch (err) {
-    debug.handlers("GET/HEAD -- Error parsing data: " + err);
+    debug.handlers("GET -- Error parsing data: " + err);
     return callback(new HttpError({
       status: 500,
       message: err.message
@@ -304,9 +309,9 @@ LDP.prototype.listContainer = function (filename, uri, containerData, callback) 
         undefined,
         resourceGraph,
         null,
-        'text/turtle');
+        contentType);
     } catch (parseErr) {
-      debug.handlers("GET/HEAD -- Error serializing container: " + parseErr);
+      debug.handlers("GET -- Error serializing container: " + parseErr);
       return callback(new HttpError({
         status: 500,
         message: parseErr.message
@@ -347,14 +352,15 @@ LDP.prototype.put = function (filePath, contents, callback) {
   });
 };
 
-LDP.prototype.get = function(filename, uri, includeBody, callback) {
+LDP.prototype.get = function (reqPath, baseUri, includeBody, contentType, callback) {
     var ldp = this;
-    ldp.stat(filename, function(err, stats) {
+    var filename = utils.uriToFilename(reqPath, ldp.root);
+    ldp.stat(filename, function (err, stats) {
         // File does not exist
         if (err) {
             return callback(new HttpError({
                 status: err.status,
-                message:"Can't read file: " + err.message
+                message: "Can't read file: " + err.message
             }));
         }
 
@@ -365,30 +371,38 @@ LDP.prototype.get = function(filename, uri, includeBody, callback) {
 
         // Found a container
         if (stats.isDirectory()) {
-            return ldp.readContainerMeta(filename, function(err, metaFile) {
+            return ldp.readContainerMeta(filename, function (err, metaFile) {
                 if (err) {
                     metaFile = '';
                 }
-                ldp.listContainer(filename, uri, metaFile, function (err, data) {
-                    if (err) {
-                        debug.handlers('GET/HEAD -- Read error:' + err.message);
-                        return callback(err);
-                    }
-                    // The ending `true`, specifies it is a container
-                    return callback(null, data, true);
+
+                ldp.listContainer(filename, baseUri, metaFile, contentType, function (err, data) {
+                  if (err) {
+                    debug.handlers('GET container -- Read error:' + err.message);
+                    return callback(err)
+                  }
+                  var stream = stringToStream(data)
+                  return callback(null, stream, contentType, true);
                 });
             });
-        }
-        else {
-            return ldp.readFile(filename, function (err, data) {
-                // Error when reading
-                if (err) {
-                    debug.handlers('GET/HEAD -- Read error:' + err.message);
-                    return callback(err);
+        } else {
+            var stream = ldp.createReadStream(filename)
+            stream
+              .on('error', function (err) {
+                  debug.handlers('GET -- Read error:' + err.message);
+                  return new HttpError({
+                    status: err.code === 'ENOENT' ? 404 : 500,
+                    message: "Can't read file: " + err
+                  })
+              })
+              .on('open', function () {
+                debug.handlers('GET -- Read Start.');
+                var contentType = mime.lookup(filename);
+                if (utils.hasSuffix(filename, ldp.turtleExtensions)) {
+                    contentType = 'text/turtle';
                 }
-                debug.handlers('GET/HEAD -- Read Ok. Bytes read: ' + data.length);
-                return callback(null, data);
-            });
+                callback(null, stream, contentType, false)
+              })
         }
     });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,10 +6,16 @@ exports.pathBasename = pathBasename;
 exports.uriBase = uriBase;
 exports.hasSuffix = hasSuffix;
 exports.getResourceLink = getResourceLink;
+exports.parse = parse;
+exports.serialize = serialize;
+exports.translate = translate;
+exports.stringToStream = stringToStream;
 
 var fs = require('fs');
 var path = require('path');
 var S = require('string');
+var $rdf = require('rdflib');
+var from = require('from2')
 
 function uriToFilename(uri, base) {
     uri = decodeURIComponent(uri)
@@ -73,4 +79,75 @@ function getResourceLink(filename, uri, base, suffix, otherSuffix) {
     } else {
         return link+suffix;
     }
+}
+
+function parse (data, baseUri, contentType, callback) {
+    var graph = $rdf.graph();
+    try {
+        $rdf.parse(data, graph, baseUri, contentType);
+    } catch (err) {
+        return callback(err);
+    }
+    return callback(null, graph)
+}
+
+function serialize (graph, baseUri, contentType, callback) {
+
+    try {
+        $rdf.serialize(null, graph, null, contentType, function (err, result) {
+            if (err) {
+                return callback(err)
+            }
+            if (result === undefined) {
+                return callback(new Error('Error serializing the graph to ' + contentType));
+            }
+
+            return callback(null, result)
+        })
+    } catch(err) {
+        callback(err)
+    }
+}
+
+function translate (stream, baseUri, from, to, callback) {
+
+    // Handle Turtle Accept header
+    if (to === 'text/turtle' ||
+        to === 'text/n3' ||
+        to === 'application/turtle' ||
+        to === 'application/n3') {
+        to = 'text/turtle'
+    }
+
+    var data = ''
+    stream
+        .on('data', function (chunk) {
+            data += chunk
+        })
+        .on('end', function () {
+            parse(data, baseUri, from, function (err, graph) {
+                if (err) return callback(err);
+                serialize(graph, baseUri, to, function (err, data) {
+                    if (err) return callback(err);
+                    callback(null, data)
+                });
+            });
+        })
+}
+ 
+function stringToStream (string) {
+  return from(function (size, next) {
+    // if there's no more content 
+    // left in the string, close the stream. 
+    if (string.length <= 0)
+        return next(null, null)
+ 
+    // Pull in a new chunk of text, 
+    // removing it from the string. 
+    var chunk = string.slice(0, size)
+    string = string.slice(size)
+ 
+    // Emit "chunk" from the stream. 
+    next(null, chunk)
+  })
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "debug": "^2.2.0",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
+    "from2": "^2.1.0",
     "fs-extra": "^0.21.0",
     "glob": "^5.0.13",
     "http-delayed-response": "0.0.4",

--- a/test/formats.js
+++ b/test/formats.js
@@ -25,15 +25,28 @@ describe('formats', function () {
         var isValidJSON = function(res) {
             var json = JSON.parse(res.text);
         };
-        it('Should return JSON-LD document if Accept is set to application/ld+json', function(done) {
+        it('Should return JSON-LD document if Accept is set to only application/ld+json', function(done) {
+            server.get('/patch-5-initial.ttl')
+                .set('accept', 'application/ld+json')
+                .expect(200)
+                .expect('content-type', /application\/ld\+json/)
+                .end(done)
+        });
+         it('Should prefer to avoid translation even if type is listed with less priority', function(done) {
             server.get('/patch-5-initial.ttl')
                 .set('accept', 'application/ld+json;q=0.9,text/turtle;q=0.8,text/plain;q=0.7,*/*;q=0.5')
+                .expect('content-type', /text\/turtle/)
+                .expect(200, done);
+        });
+        it('Should return JSON-LD document if Accept is set to application/ld+json and other types', function(done) {
+            server.get('/patch-5-initial.ttl')
+                .set('accept', 'application/ld+json;q=0.9,application/rdf+xml;q=0.7')
                 .expect('content-type', /application\/ld\+json/)
                 .expect(200, done);
         });
         it('Should return valid JSON if Accept is set to JSON-LD', function(done) {
             server.get('/patch-5-initial.ttl')
-                .set('accept', 'application/ld+json;q=0.9,text/turtle;q=0.8,text/plain;q=0.7,*/*;q=0.5')
+                .set('accept', 'application/ld+json')
                 .expect(isValidJSON)
                 .expect(200, done);
         });
@@ -42,7 +55,7 @@ describe('formats', function () {
     describe('N-Quads', function() {
         it('Should return N-Quads document is Accept is set to application/n-quads', function(done) {
             server.get('/patch-5-initial.ttl')
-                .set('accept', 'application/n-quads;q=0.9,text/turtle;q=0.8,text/plain;q=0.7,*/*;q=0.5')
+                .set('accept', 'application/n-quads;q=0.9,application/ld+json;q=0.8,application/rdf+xml;q=0.7')
                 .expect('content-type', /application\/n-quads/)
                 .expect(200, done);
         });
@@ -51,7 +64,7 @@ describe('formats', function () {
     describe('n3', function() {
         it('Should return turtle document if Accept is set to text/n3', function(done) {
             server.get('/patch-5-initial.ttl')
-                .set('accept', 'text/n3;q=0.9,text/turtle;q=0.8,text/plain;q=0.7,*/*;q=0.5')
+                .set('accept', 'text/n3;q=0.9,application/n-quads;q=0.7,text/plain;q=0.7')
                 .expect('content-type', /text\/n3/)
                 .expect(200, done);
         });

--- a/test/http.js
+++ b/test/http.js
@@ -131,20 +131,23 @@ describe('HTTP APIs', function() {
               .expect(200, done);
       });
 
-      it('should have set Link as resource', function(done) {
+      it('should have set Link as resource', function (done) {
         server.get('/sampleContainer/example1.ttl')
+            .expect('content-type', /text\/turtle/)
             .expect('Link', /<http:\/\/www.w3.org\/ns\/ldp#Resource>; rel="type"/)
             .expect(200, done);
       });
       it('should have set acl and describedBy Links for resource', function(done) {
         server.get('/sampleContainer/example1.ttl')
+            .expect('content-type', /text\/turtle/)
             .expect(hasHeader('acl', 'example1.ttl' + suffixAcl))
             .expect(hasHeader('describedBy', 'example1.ttl' + suffixMeta))
             .end(done);
       });
 
       it('should have set Link as Container/BasicContainer', function(done) {
-        server.head('/sampleContainer/')
+        server.get('/sampleContainer/')
+            .expect('content-type', /text\/turtle/)
             .expect('Link', /<http:\/\/www.w3.org\/ns\/ldp#BasicContainer>; rel="type"/)
             .expect('Link', /<http:\/\/www.w3.org\/ns\/ldp#Container>; rel="type"/)
             .expect(200, done);
@@ -156,11 +159,13 @@ describe('HTTP APIs', function() {
       it('should return basic container link for directories', function(done) {
           server.get('/')
               .expect('Link', /http:\/\/www.w3.org\/ns\/ldp#BasicContainer/)
+              .expect('content-type', /text\/turtle/)
               .expect(200, done);
       });
       it('should return resource link for files', function(done) {
           server.get('/hello.html')
               .expect('Link', /<http:\/\/www.w3.org\/ns\/ldp#Resource>; rel="type"/)
+              .expect('Content-Type', 'text/html')
               .expect(200, done);
       });
       it('should have glob support', function(done) {

--- a/test/ldp.js
+++ b/test/ldp.js
@@ -91,7 +91,7 @@ describe('LDP', function () {
             '   dcterms:title "This is a magic type" ;' +
             '   o:limit 500000.00 .', 'sampleContainer/magicType.ttl');
 
-      ldp.listContainer(__dirname + '/resources/sampleContainer/', 'https://server.tld', '', function (err, data) {
+      ldp.listContainer(__dirname + '/resources/sampleContainer/', 'https://server.tld', '', 'text/turtle', function (err, data) {
         var graph = $rdf.graph();
         $rdf.parse(
           data,
@@ -130,7 +130,7 @@ describe('LDP', function () {
             '   dcterms:title "This is a container" ;' +
             '   o:limit 500000.00 .', 'sampleContainer/basicContainerFile.ttl');
 
-      ldp.listContainer(__dirname + '/resources/sampleContainer/', 'https://server.tld', '', function (err, data) {
+      ldp.listContainer(__dirname + '/resources/sampleContainer/', 'https://server.tld', '', 'text/turtle', function (err, data) {
         var graph = $rdf.graph();
         $rdf.parse(
           data,
@@ -167,7 +167,7 @@ describe('LDP', function () {
     });
 
     it('should ldp:contains the same amount of files in dir', function(done) {
-      ldp.listContainer(__dirname + '/resources/sampleContainer/', 'https://server.tld', '', function (err, data) {
+      ldp.listContainer(__dirname + '/resources/sampleContainer/', 'https://server.tld', '', 'text/turtle', function (err, data) {
         fs.readdir(__dirname + '/resources/sampleContainer/', function(err, files) {
           var graph = $rdf.graph();
           $rdf.parse(


### PR DESCRIPTION
- Using streams when serving files
- Translate only when possible
- Fix mess with negotiation
- Added some tests

also, we got for free:
- Possibility to translate containers

--
It was a consistent amount of piping and cleaning, now it is very simple, the workflow is the following:

1. User asks for type x, y, z of FILE
2. We find the file and check if the mimetype matches x, y or z and uses the one which does not need any translation, otherwise translate
3. If translation is not possible 406 is given,

my key change is on line 55-97, the rest is to support streams