### PR TITLE
Deprecating parse

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -9,6 +9,7 @@ var LdpMiddleware = require('./ldp-middleware')
 var proxy = require('./handlers/proxy')
 var IdentityProvider = require('./identity-provider')
 var vhost = require('vhost')
+
 var corsSettings = cors({
   methods: [
     'OPTIONS', 'HEAD', 'GET',

--- a/lib/ldp-middleware.js
+++ b/lib/ldp-middleware.js
@@ -4,7 +4,6 @@ var express = require('express')
 var getRawBody = require('raw-body')
 var responseTime = require('response-time')
 var header = require('./header')
-var parse = require('./parse')
 var acl = require('./acl')
 var login = require('./login')
 var getHandler = require('./handlers/get.js')
@@ -47,7 +46,8 @@ function LdpMiddleware (corsSettings) {
   router.delete('/*', acl.allow('Write'))
 
   // Convert json-ld and nquads to turtle
-  router.use('/*', parse.parseHandler)
+  // TODO: in the process of being deprecated
+  // router.use('/*', parse.parseHandler)
 
   // Add response time
   router.use(responseTime())

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,84 +1,85 @@
-exports.parseHandler = parseHandler
-exports.convertToTurtle = convertToTurtle
+// TODO: in the process of being deprecated
+// exports.parseHandler = parseHandler
+// exports.convertToTurtle = convertToTurtle
 
-var N3 = require('n3')
-var jsonld = require('jsonld')
-var debug = require('./debug').parse
+// var N3 = require('n3')
+// var jsonld = require('jsonld')
+// var debug = require('./debug').parse
 
-function parseHandler (req, res, next) {
-  convertToTurtle(req.text, req, function (err, result) {
-    if (!err) {
-      req.convertedText = result
-    } else {
-      debug('Error parsing request: ' + err)
-    }
-    return next()
-  })
-}
+// function parseHandler (req, res, next) {
+//   convertToTurtle(req.text, req, function (err, result) {
+//     if (!err) {
+//       req.convertedText = result
+//     } else {
+//       debug('Error parsing request: ' + err)
+//     }
+//     return next()
+//   })
+// }
 
-function convertToTurtle (rawDocument, req, convertCallback) {
-  if (req.is('application/ld+json') ||
-    req.is('application/nquads') || req.is('application/n-quads')) {
-    var contentType = req.get('content-type').split(';')[0].trim()
-    parse(rawDocument, contentType, convertCallback)
-  } else {
-    convertCallback(null, rawDocument)
-  }
-}
+// function convertToTurtle (rawDocument, req, convertCallback) {
+//   if (req.is('application/ld+json') ||
+//     req.is('application/nquads') || req.is('application/n-quads')) {
+//     var contentType = req.get('content-type').split(';')[0].trim()
+//     parse(rawDocument, contentType, convertCallback)
+//   } else {
+//     convertCallback(null, rawDocument)
+//   }
+// }
 
-function parse (rawDocument, contentType, convertCallback) {
-  var n3Parser = N3.Parser()
-  var n3Writer
-  var triples = []
-  var prefixes = {}
+// function parse (rawDocument, contentType, convertCallback) {
+//   var n3Parser = N3.Parser()
+//   var n3Writer
+//   var triples = []
+//   var prefixes = {}
 
-  if (contentType === 'application/ld+json') {
-    var jsonDocument
-    try {
-      jsonDocument = JSON.parse(rawDocument)
-    } catch (err) {
-      convertCallback(err, null)
-    }
-    jsonld.toRDF(jsonDocument, {
-      format: 'application/nquads'
-    }, nquadCallback)
-  } else if (contentType === 'application/nquads' ||
-    contentType === 'application/n-quads') {
-    nquadCallback(null, rawDocument)
-  } else {
-    convertCallback(new Error('Wrong content type'), null)
-  }
+//   if (contentType === 'application/ld+json') {
+//     var jsonDocument
+//     try {
+//       jsonDocument = JSON.parse(rawDocument)
+//     } catch (err) {
+//       convertCallback(err, null)
+//     }
+//     jsonld.toRDF(jsonDocument, {
+//       format: 'application/nquads'
+//     }, nquadCallback)
+//   } else if (contentType === 'application/nquads' ||
+//     contentType === 'application/n-quads') {
+//     nquadCallback(null, rawDocument)
+//   } else {
+//     convertCallback(new Error('Wrong content type'), null)
+//   }
 
-  function nquadCallback (err, nquads) {
-    if (err) {
-      debug('Error parsing nquads: ' + err)
-      convertCallback(err, null)
-    }
-    try {
-      n3Parser.parse(nquads, tripleCallback, prefixCallback)
-    } catch (err) {
-      convertCallback(err, null)
-    }
-  }
+//   function nquadCallback (err, nquads) {
+//     if (err) {
+//       debug('Error parsing nquads: ' + err)
+//       convertCallback(err, null)
+//     }
+//     try {
+//       n3Parser.parse(nquads, tripleCallback, prefixCallback)
+//     } catch (err) {
+//       convertCallback(err, null)
+//     }
+//   }
 
-  function tripleCallback (err, triple, prefixes) {
-    if (err) {
-      convertCallback(err, null)
-    }
-    if (triple) {
-      triples.push(triple)
-    } else {
-      n3Writer = N3.Writer({
-        prefixes: prefixes
-      })
-      for (var i = 0; i < triples.length; i++) {
-        n3Writer.addTriple(triples[i])
-      }
-      n3Writer.end(convertCallback)
-    }
-  }
+//   function tripleCallback (err, triple, prefixes) {
+//     if (err) {
+//       convertCallback(err, null)
+//     }
+//     if (triple) {
+//       triples.push(triple)
+//     } else {
+//       n3Writer = N3.Writer({
+//         prefixes: prefixes
+//       })
+//       for (var i = 0; i < triples.length; i++) {
+//         n3Writer.addTriple(triples[i])
+//       }
+//       n3Writer.end(convertCallback)
+//     }
+//   }
 
-  function prefixCallback (prefix, iri) {
-    prefixes[prefix] = iri
-  }
-}
+//   function prefixCallback (prefix, iri) {
+//     prefixes[prefix] = iri
+//   }
+// }


### PR DESCRIPTION
Current code translates the request into a ttl (from nquads and JSON-ld).

This PR comments that out, since there is no need.
@deiu asked me if I could just comment out for now and remove the code later