### PR TITLE
Removing function isMetadataFile

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -44,7 +44,7 @@ function linksHandler (req, res, next) {
   var filename = utils.uriToFilename(req.url, root)
 
   filename = path.join(filename, req.path)
-  if (ldp.isMetadataFile(filename)) {
+  if (path.extname(filename) === ldp.suffixMeta) {
     debug.metadata('Trying to access metadata file as regular file.')
 
     return next(error(404, 'Trying to access metadata file as regular file'))

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -462,10 +462,3 @@ LDP.prototype.getAvailablePath = function (host, containerURI, slug, callback) {
       callback(newPath)
     })
 }
-
-LDP.prototype.isMetadataFile = function (filename) {
-  if (path.extname(filename) === this.suffixMeta) {
-    return true
-  }
-  return false
-}


### PR DESCRIPTION
I am currently removing unused functions from ldp.
This function is only called once and it does some trivial string checking,
there is no need for a function