### PR TITLE
Document `createAdmin` flag (single user mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 *.swp
 .tern-port
 npm-debug.log
+.acl
+profile/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Options:
   -C, --cert                  Path to the ssl cert file
   --webid                     Enable WebID+TLS authentication
   -idp, --identity-provider   Allow registration of WebIDs
+  --create-admin              Allow a user to set up their initial identity in single-user mode
   -s, --secret                HTTP Session cookie secret key (e.g. "your secret phrase")
   -fU, --force-user           Force a WebID to always be logged in (useful when offline)
   -P, --proxy                 Use a proxy on example.tld/proxyPath
@@ -53,21 +54,37 @@ Options:
 
 ### Running the server
 
-#### Solid server mode (HTTPS / WebID enabled)
+#### Solid server, Single User mode (HTTPS / WebID enabled)
 
-To start `ldnode` in Solid server mode, you will need to enable the `--webid`
-flag, and also pass in a valid SSL key and certificate files:
+To start `ldnode` in Solid Single User mode, you will need to enable the
+`--webid` flag, and also pass in a valid SSL key and certificate files.
+LDNode will use these certificates for its own server use (these are
+different from the Admin user identity certificate discussed below).
+
+**Initial Admin User Setup:**
+The *first* time you run `ldnode`, you will also want to use the
+`--create-admin` flag, to set up the initial Admin user identity and
+certificates.
+
+```bash
+ldnode --webid --port 8443 --cert /path/to/cert --key /path/to/key --create-admin
+```
+
+You can then visit your LDNode server (at `https://localhost:8443/`, if you're
+running it locally), and set up a new account.
+
+You should then restart `ldnode`, this time without the `--create-admin` flag:
 
 ```bash
 ldnode --webid --port 8443 --cert /path/to/cert --key /path/to/key
 ```
 
-#### Solid server mode with WebID Identity Provider
+#### Solid server, Multi-user Mode (Allows account creation)
 
 To allow users to create a WebID on your server:
 
 ```bash
-$ ldnode --webid --port 8443 --cert /path/to/cert --key /path/to/key -idp --root ./accounts
+ldnode --webid --port 8443 --cert /path/to/cert --key /path/to/key -idp --root ./accounts
 ```
 
 Your users will have a dedicated folder under `./accounts`. Also, your root domain's website will be in `./accounts/yourdomain.tld`.

--- a/bin/ldnode.js
+++ b/bin/ldnode.js
@@ -100,7 +100,7 @@ var argv = require('nomnom')
   .option('createAdmin', {
     full: 'create-admin',
     flag: true,
-    help: 'Allow a user to set up its initial identity'
+    help: 'Allow a user to set up their initial identity in single-user mode'
   })
   .parse()
 


### PR DESCRIPTION
Add README docs for initial Admin user signup in single user mode.
Addresses second item of issue https://github.com/solid/solid/issues/7

(Also adds the initial user account's `/profile` and `.acl` to `.gitignore`.)