### PR TITLE
Fix crash when requesting a container as `application/ld+json`

### DIFF
--- a/test/http.js
+++ b/test/http.js
@@ -150,6 +150,12 @@ describe('HTTP APIs', function () {
   })
 
   describe('GET API', function () {
+    it('should handle ld+json requests to containers', function (done) {
+      server.get('/sampleContainer/')
+        .set('Accept', 'application/ld+json')
+        .expect(200, done)
+    })
+
     it('should have the same size of the file on disk', function (done) {
       server.get('/sampleContainer/solid.png')
         .expect(200)


### PR DESCRIPTION
Starting a PR:

- add failing tests that highlight issue #223 (doing a GET on a container with `Accept: application/ld+json`).