### PR TITLE
now containers return jsonld if requested so

### DIFF
--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -13,6 +13,7 @@ var utils = require('./utils')
 var ns = require('./vocab/ns').ns
 var error = require('./http-error')
 var stringToStream = require('./utils').stringToStream
+var serialize = require('./utils').serialize
 var extend = require('extend')
 var doWhilst = require('async').doWhilst
 var rimraf = require('rimraf')
@@ -297,18 +298,15 @@ LDP.prototype.listContainer = function (filename, uri, containerData, contentTyp
     if (err) {
       return callback(error(500, err.message))
     }
-    var turtleData
-    try {
-      turtleData = $rdf.serialize(
-        undefined,
-        resourceGraph,
-        null,
-        contentType)
-    } catch (parseErr) {
-      debug.handlers('GET -- Error serializing container: ' + parseErr)
-      return callback(error(500, parseErr.message))
-    }
-    return callback(null, turtleData)
+    // TODO 'text/turtle' is fixed, should be contentType instead
+    // This forces one more translation turtle -> desired
+    serialize(resourceGraph, null, 'text/turtle', function (err, result) {
+      if (err) {
+        debug.handlers('GET -- Error serializing container: ' + err)
+        return callback(error(500, err.message))
+      }
+      return callback(null, result)
+    })
   })
 }
 
@@ -393,7 +391,9 @@ LDP.prototype.get = function (host, reqPath, baseUri, includeBody, contentType, 
             return callback(err)
           }
           var stream = stringToStream(data)
-          return callback(null, stream, contentType, true)
+          // TODO 'text/turtle' is fixed, should be contentType instead
+          // This forces one more translation turtle -> desired
+          return callback(null, stream, 'text/turtle', true)
         })
       })
     } else {

--- a/test/formats.js
+++ b/test/formats.js
@@ -29,6 +29,13 @@ describe('formats', function () {
         .expect('content-type', /application\/ld\+json/)
         .end(done)
     })
+    it('should return the container listing in JSON-LD if Accept is set to only application/ld+json', function (done) {
+      server.get('/')
+        .set('accept', 'application/ld+json')
+        .expect(200)
+        .expect('content-type', /application\/ld\+json/)
+        .end(done)
+    })
     it('should prefer to avoid translation even if type is listed with less priority', function (done) {
       server.get('/patch-5-initial.ttl')
         .set('accept', 'application/ld+json;q=0.9,text/turtle;q=0.8,text/plain;q=0.7,*/*;q=0.5')


### PR DESCRIPTION
This solution is a bit of a hack.

`Jsonld` apparently does not like relative urls (it needs a base `@id:`). When we list the containment triple, we use relative paths; so, when we serialize to `jsonld`, the serializer complains for this reason.

This fix forces the containment triples to be formatted in text/turtle and later on converted to jsonld (in constrast on how it should be: directly serialize to jsonld). This _hack_ works because when we translate from `turtle` to `jsonld` we pass a base url that `jsonld` will be using (so it will drop relative paths).

Before we merge this, it would be great to have a better understanding on the jsonld library.

__Note__: (1) in the code I left two TODO showing when I force the translation to happen. (2) I readded the test used by dmitry