### PR TITLE
Fix redirect

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -62,15 +62,12 @@ function handler (req, res, next) {
 
     // Redirect to container with / if missing
     if (container && path.lastIndexOf('/') !== path.length - 1) {
-      debug(contentType)
       return res.redirect(301, _path.join(path, '/'))
     }
 
     // Till here it must exist
     if (!includeBody) {
       debug('HEAD only')
-      // res.set('Content-Type', contentType)
-      // res.set()
       res.sendStatus(200)
       return next()
     }

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -2,7 +2,7 @@ module.exports = handler
 
 var fs = require('fs')
 var glob = require('glob')
-var path = require('path')
+var _path = require('path')
 var $rdf = require('rdflib')
 var S = require('string')
 var async = require('async')
@@ -60,9 +60,17 @@ function handler (req, res, next) {
       return next(err)
     }
 
+    // Redirect to container with / if missing
+    if (container && path.lastIndexOf('/') !== path.length - 1) {
+      debug(contentType)
+      return res.redirect(301, _path.join(path, '/'))
+    }
+
     // Till here it must exist
     if (!includeBody) {
       debug('HEAD only')
+      // res.set('Content-Type', contentType)
+      // res.set()
       res.sendStatus(200)
       return next()
     }
@@ -174,7 +182,7 @@ function aclAllow (match, req, res, callback) {
   }
 
   var root = ldp.idp ? ldp.root + req.hostname + '/' : ldp.root
-  var relativePath = '/' + path.relative(root, match)
+  var relativePath = '/' + _path.relative(root, match)
   res.locals.path = relativePath
   acl.allow('Read', req, res, function (err) {
     callback(err)

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -383,7 +383,7 @@ LDP.prototype.get = function (host, reqPath, baseUri, includeBody, contentType, 
 
     // Just return, since resource exists
     if (!includeBody) {
-      return callback(null, stats)
+      return callback(null, stats, contentType, stats.isDirectory())
     }
 
     // Found a container

--- a/test/acl.js
+++ b/test/acl.js
@@ -462,14 +462,6 @@ describe('ACL HTTP', function () {
         done()
       })
     })
-    it('user1 should be able to access test directory without trailing slash in the url', function (done) {
-      var options = createOptions('/acl/read-acl', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
     it('user1 should be able to modify ACL file', function (done) {
       var options = createOptions('/acl/read-acl/.acl', 'user1')
       options.headers = {

--- a/test/http.js
+++ b/test/http.js
@@ -173,13 +173,12 @@ describe('HTTP APIs', function () {
     })
 
     it('should have Access-Control-Allow-Origin as Origin on containers', function (done) {
-      server.get('/sampleContainer')
+      server.get('/sampleContainer/')
         .set('Origin', 'http://example.com')
         .expect('content-type', /text\/turtle/)
         .expect('Access-Control-Allow-Origin', 'http://example.com')
         .expect(200, done)
     })
-
     it('should have Access-Control-Allow-Origin as Origin on resources',
       function (done) {
         server.get('/sampleContainer/example1.ttl')
@@ -220,6 +219,10 @@ describe('HTTP APIs', function () {
         .set('Accept', 'text/html')
         .expect('content-type', /text\/html/)
         .expect(200, done) // Can't check for 303 because of internal redirects
+    })
+    it('should redirect to the right container URI if missing /', function (done) {
+      server.get('/sampleContainer')
+        .expect(301, done)
     })
     it('should return 404 for non-existent resource', function (done) {
       server.get('/invalidfile.foo')
@@ -486,7 +489,7 @@ describe('HTTP APIs', function () {
         })
     })
     it('should be able to access newly container', function (done) {
-      server.get('/post-tests/loans')
+      server.get('/post-tests/loans/')
         .expect('content-type', /text\/turtle/)
         .expect(200, done)
     })


### PR DESCRIPTION
Redirect `/foo` to `/foo/` if missing slash and the resource is a container.