### PR TITLE
Redirect /foo to /foo/ even when handling index.html

### DIFF
--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -14,15 +14,20 @@ function handler (req, res, next) {
   var requestedType = negotiator.mediaType()
   var filename = utils.reqToPath(req)
 
-  if (requestedType.indexOf('text/html') !== 0) {
-    return next()
-  }
-
   ldp.stat(filename, function (err, stats) {
     if (err) return next()
 
     res.locals.path = req.path
     if (stats.isDirectory()) {
+      // redirect to the right container if missing trailing /
+      if (req.path.lastIndexOf('/') !== req.path.length - 1) {
+        return res.redirect(301, path.join(req.path, '/'))
+      }
+
+      if (requestedType.indexOf('text/html') !== 0) {
+        return next()
+      }
+
       res.locals.path = path.join(req.path, indexFile)
     }
     debug('Looking for index in ' + res.locals.path)

--- a/test/http.js
+++ b/test/http.js
@@ -278,6 +278,13 @@ describe('HTTP APIs', function () {
           })
           .end(done)
       })
+    it('should still redirect to the right container URI if missing / and HTML is requested',
+      function (done) {
+        server.get('/sampleContainer')
+          .set('accept', 'text/html')
+          .expect('location', /\/sampleContainer\//)
+          .expect(301, done)
+      })
   })
 
   describe('HEAD API', function () {


### PR DESCRIPTION
Previously, ldnode did not redirect `/foo` to `/foo/` if the request was caught by the index handler.