### PR TITLE
Fix ACL check for internal index.html redirect

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -60,11 +60,6 @@ function handler (req, res, next) {
       return next(err)
     }
 
-    // Redirect to container with / if missing
-    if (container && path.lastIndexOf('/') !== path.length - 1) {
-      return res.redirect(301, _path.join(path, '/'))
-    }
-
     // Till here it must exist
     if (!includeBody) {
       debug('HEAD only')

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -16,26 +16,25 @@ function handler (req, res, next) {
     if (err) return next()
 
     res.locals.path = req.path
-    if (stats.isDirectory()) {
-      // redirect to the right container if missing trailing /
-      if (req.path.lastIndexOf('/') !== req.path.length - 1) {
-        return res.redirect(301, path.join(req.path, '/'))
-      }
+    if (!stats.isDirectory()) {
+      return next()
+    }
+    // redirect to the right container if missing trailing /
+    if (req.path.lastIndexOf('/') !== req.path.length - 1) {
+      return res.redirect(301, path.join(req.path, '/'))
+    }
 
-      if (requestedType.indexOf('text/html') !== 0) {
-        return next()
-      }
-
-      res.locals.path = path.join(req.path, indexFile)
+    if (requestedType.indexOf('text/html') !== 0) {
+      return next()
     }
     debug('Looking for index in ' + res.locals.path)
 
-    // Check if file exists in first place
+  // Check if file exists in first place
     ldp.exists(req.hostname, res.locals.path, function (err) {
       if (err) {
-        res.locals.path = req.path
         return next()
       }
+      res.locals.path = path.join(req.path, indexFile)
       debug('Found an index for current path')
       return next()
     })

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -2,8 +2,6 @@ module.exports = handler
 
 var path = require('path')
 var debug = require('debug')('ldnode:index')
-var acl = require('../acl')
-var get = require('./get')
 var utils = require('../utils')
 var Negotiator = require('negotiator')
 
@@ -39,19 +37,7 @@ function handler (req, res, next) {
         return next()
       }
       debug('Found an index for current path')
-      // Since it exists, can the user read this?
-      acl.allow('Read')(req, res, function (err) {
-        if (err) {
-          res.locals.path = req.path
-          return next()
-        }
-        debug('current agent can read it')
-        // Send the file
-        get(req, res, function (err) {
-          if (err) return next()
-          // file is already sent, no action needed
-        })
-      })
+      return next()
     })
   })
 }

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -15,7 +15,6 @@ function handler (req, res, next) {
   ldp.stat(filename, function (err, stats) {
     if (err) return next()
 
-    res.locals.path = req.path
     if (!stats.isDirectory()) {
       return next()
     }

--- a/lib/ldp-middleware.js
+++ b/lib/ldp-middleware.js
@@ -22,7 +22,7 @@ function LdpMiddleware (corsSettings) {
   }
 
   router.use('/*', authentication)
-  router.get('/*', acl.allow('Read'), index, get)
+  router.get('/*', index, acl.allow('Read'), get)
   router.post('/*', acl.allow('Append'), post)
   router.patch('/*', acl.allow('Append'), patch)
   router.put('/*', acl.allow('Write'), put)

--- a/test/acl.js
+++ b/test/acl.js
@@ -78,7 +78,7 @@ describe('ACL HTTP', function () {
 
   describe('no ACL', function () {
     it('should return 403 for any resource', function (done) {
-      var options = createOptions('/acl/no-acl', 'user1')
+      var options = createOptions('/acl/no-acl/', 'user1')
       request(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
@@ -86,7 +86,7 @@ describe('ACL HTTP', function () {
       })
     })
     it('should have `User` set in the Response Header', function (done) {
-      var options = createOptions('/acl/no-acl', 'user1')
+      var options = createOptions('/acl/no-acl/', 'user1')
       request(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)

--- a/test/http.js
+++ b/test/http.js
@@ -235,7 +235,7 @@ describe('HTTP APIs', function () {
       server.get('/sampleContainer/')
         .set('Accept', 'text/html')
         .expect('content-type', /text\/html/)
-        .expect(200, done) // Can't check for 303 because of internal redirects
+        .expect(303, done)
     })
     it('should redirect to the right container URI if missing /', function (done) {
       server.get('/sampleContainer')
@@ -286,13 +286,8 @@ describe('HTTP APIs', function () {
       function (done) {
         server.get('/sampleContainer/')
           .set('accept', 'text/html')
-          .expect(200)
+          .expect(303)
           .expect('content-type', /text\/html/)
-          .expect(function (res) {
-            if (res.text.indexOf('<!DOCTYPE html>') < 0) {
-              throw new Error('wrong content returned for index.html')
-            }
-          })
           .end(done)
       })
     it('should still redirect to the right container URI if missing / and HTML is requested',


### PR DESCRIPTION
Given a private container `/foo/` and a public document `/foo/index.html`, lnode's ACL system currently checks if `/foo/` is readable before passing the request to the index handler, therefore blocking access to `/foo/index.html`.

This PR introduces a fix, where the index handler takes precedence over the ACL check for read operations (GET).