### PR TITLE
Avoid walking the path to https:/.acl

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -256,6 +256,7 @@ function possibleACLs (uri, suffix) {
   }
 
   var times = parsedUri.pathname.split('/').length
+  // TODO: improve temporary solution to stop recursive path walking above root
   if (parsedUri.pathname.endsWith('/')) {
     times--
   }

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -256,6 +256,10 @@ function possibleACLs (uri, suffix) {
   }
 
   var times = parsedUri.pathname.split('/').length
+  if (parsedUri.pathname.endsWith('/')) {
+    times--
+  }
+
   for (var i = 0; i < times - 1; i++) {
     uri = path.dirname(uri)
     urls.push(uri + (uri[uri.length - 1] === '/' ? suffix : '/' + suffix))


### PR DESCRIPTION
Before, the ACL code was walked the path in reverse order, leading up to `https:/.acl` instead of `https://localhost/.acl`.