### PR TITLE
Add fallthrough for failed auth

### DIFF
--- a/lib/handlers/authentication.js
+++ b/lib/handlers/authentication.js
@@ -2,7 +2,6 @@ module.exports = handler
 
 var webid = require('webid/tls')
 var debug = require('../debug').authentication
-var error = require('../http-error')
 
 function handler (req, res, next) {
   var ldp = req.app.locals.ldp

--- a/lib/handlers/authentication.js
+++ b/lib/handlers/authentication.js
@@ -41,7 +41,7 @@ function handler (req, res, next) {
     if (err) {
       debug('Error processing certificate: ' + err.message)
       setEmptySession(req)
-      return next(error(403, 'Forbidden'))
+      return next()
     }
     req.session.userId = result
     req.session.identified = true


### PR DESCRIPTION
The auth logic should not return 403 if a user fails to authenticate. The process should continue as if the user did not provide any credentials.